### PR TITLE
API fixes for missing endpoints

### DIFF
--- a/src/api/connectors/SpotifyConnector.ts
+++ b/src/api/connectors/SpotifyConnector.ts
@@ -6,7 +6,8 @@ import {
     SpotifyEpisodesMetadataPayload,
     SpotifyPodcastMetadataPayload,
     SpotifyListenersPayload,
-    SpotifyAggregatePayload,
+    SpotifyPodcastAggregatePayload,
+    SpotifyEpisodeAggregatePayload,
     SpotifyPerformancePayload,
     SpotifyPodcastFollowersPayload,
 } from '../../types/connector'
@@ -111,13 +112,13 @@ class SpotifyConnector implements ConnectorHandler {
                     accountId,
                     payload.meta.episode,
                     payload.range.start,
-                    payload.data as SpotifyAggregatePayload
+                    payload.data as SpotifyEpisodeAggregatePayload
                 )
             } else {
                 return await this.repo.storePodcastAggregate(
                     accountId,
                     payload.range.start,
-                    payload.data as SpotifyAggregatePayload
+                    payload.data as SpotifyPodcastAggregatePayload
                 )
             }
         } else {

--- a/src/db/SpotifyRepository.ts
+++ b/src/db/SpotifyRepository.ts
@@ -1,6 +1,6 @@
 import { Pool } from 'mysql2/promise'
 import {
-    SpotifyAggregatePayload,
+    SpotifyPodcastAggregatePayload,
     SpotifyDetailedStreamsPayload,
     SpotifyEpisodeMetadata,
     SpotifyEpisodesMetadataPayload,
@@ -9,6 +9,7 @@ import {
     SpotifyPerformancePayload,
     SpotifyPodcastFollowersPayload,
     SpotifyPodcastMetadataPayload,
+    SpotifyEpisodeAggregatePayload,
 } from '../types/connector'
 
 class SpotifyRepository {
@@ -225,7 +226,7 @@ class SpotifyRepository {
         accountId: number,
         episodeId: string,
         date: string,
-        payload: SpotifyAggregatePayload
+        payload: SpotifyEpisodeAggregatePayload
     ): Promise<any> {
         const replaceStmt = `REPLACE INTO spotifyEpisodeAggregate (account_id, episode_id, spa_date, spa_facet, spa_facet_type, 
             spa_gender_not_specified, spa_gender_female, spa_gender_male, spa_gender_non_binary) VALUES (?,?,?,?,?,?,?,?,?)`
@@ -241,22 +242,6 @@ class SpotifyRepository {
                         date,
                         ageGroup,
                         'age',
-                        entry.counts.NOT_SPECIFIED,
-                        entry.counts.FEMALE,
-                        entry.counts.MALE,
-                        entry.counts.NON_BINARY,
-                    ])
-                }
-            ),
-            ...Object.keys(payload.countryFacetedCounts).map(
-                async (country: string): Promise<any> => {
-                    const entry = payload.countryFacetedCounts[country]
-                    return await this.pool.execute(replaceStmt, [
-                        accountId,
-                        episodeId,
-                        date,
-                        entry.countryCode,
-                        'country',
                         entry.counts.NOT_SPECIFIED,
                         entry.counts.FEMALE,
                         entry.counts.MALE,
@@ -281,7 +266,7 @@ class SpotifyRepository {
     async storePodcastAggregate(
         accountId: number,
         date: string,
-        payload: SpotifyAggregatePayload
+        payload: SpotifyPodcastAggregatePayload
     ): Promise<any> {
         const replaceStmt = `REPLACE INTO spotifyPodcastAggregate (account_id, spa_date, spa_facet, spa_facet_type, 
             spa_gender_not_specified, spa_gender_female, spa_gender_male, spa_gender_non_binary) VALUES (?,?,?,?,?,?,?,?)`

--- a/src/schema/spotify/aggregate.json
+++ b/src/schema/spotify/aggregate.json
@@ -119,7 +119,6 @@
     "required": [
         "count",
         "ageFacetedCounts",
-        "countryFacetedCounts",
         "genderedCounts"
     ]
 }

--- a/src/schema/spotify/episodesMetadata.json
+++ b/src/schema/spotify/episodesMetadata.json
@@ -73,10 +73,6 @@
         }
     },
     "required": [
-        "episodes",
-        "totalPages",
-        "currentPage",
-        "totalEpisodes",
-        "metadata"
+        "episodes"
     ]
 }

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -53,7 +53,7 @@ export interface SpotifyGenderCounts {
     [k: string]: unknown
 }
 
-export interface SpotifyAggregatePayload {
+export interface SpotifyPodcastAggregatePayload {
     count: number
     ageFacetedCounts: {
         [ageGroup: string]: SpotifyGenderCounts
@@ -71,6 +71,15 @@ export interface SpotifyAggregatePayload {
     }
     genderedCounts: SpotifyGenderCounts
 }
+
+export interface SpotifyEpisodeAggregatePayload {
+    count: number
+    ageFacetedCounts: {
+        [ageGroup: string]: SpotifyGenderCounts
+    }
+    genderedCounts: SpotifyGenderCounts
+}
+
 export interface SpotifyPodcastMetadataPayload {
     totalEpisodes: number
     starts: number


### PR DESCRIPTION
* aggregate does not always include country data.
   This is often the case when the time range is very short (1 day)
* The spotify connector automatically paginates over episodes
   so the `totalPages`, `currentPage`, and `totalEpisodes` fields are
   no longer part of the payload