### PR TITLE
Add better check in case accounts map is empty

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,7 @@ class Config {
      * */
     getAccountsMap(): { [key: string]: number } {
         const accounts = this.readStringFromEnvOrFile('ACCOUNTS', '{}')
-        if (accounts) {
+        if (accounts !== undefined && accounts !== '{}') {
             const accountMap = JSON.parse(accounts)
             return accountMap
         } else {


### PR DESCRIPTION
Just a simple fix because an empty value would not trigger an error message before.

In case of an empty env var, the default value `{}` gets used, which obviously isn't empty. This leads to a scenario where no API keys get accepted.