### PR TITLE
store historical Performance/LTR data

### DIFF
--- a/db_schema/queries/v1/episodesLTR.sql
+++ b/db_schema/queries/v1/episodesLTR.sql
@@ -28,6 +28,7 @@ apple as (
 SELECT 
 apple.raw_name as name,
 guid,
+aed_date as `date`,
 ((spotify.quarter1*spotify.listeners)+(apple.quarter1*apple.listeners))/(spotify.listeners+apple.listeners) as quarter1_combined,
 ((spotify.quarter2*spotify.listeners)+(apple.quarter2*apple.listeners))/(spotify.listeners+apple.listeners) as quarter2_combined,
 ((spotify.quarter3*spotify.listeners)+(apple.quarter3*apple.listeners))/(spotify.listeners+apple.listeners) as quarter3_combined,

--- a/db_schema/queries/v1/episodesLTR.sql
+++ b/db_schema/queries/v1/episodesLTR.sql
@@ -8,7 +8,8 @@ spotify as (
   `spotifyEpisodePerformance`.`spp_percentile_100` as quarter4,
   spp_sample_max as listeners
   FROM `spotifyEpisodePerformance`
-  LEFT JOIN `spotifyEpisodeMetadata` `SpotifyEpisodeMetadata` ON `spotifyEpisodePerformance`.`episode_id` = `SpotifyEpisodeMetadata`.`episode_id`
+  LEFT JOIN `SpotifyEpisodeMetadata` USING (episode_id)
+  WHERE spp_date >= @start AND spp_date <= @end
 ),
 apple as (
   SELECT 
@@ -21,6 +22,7 @@ apple as (
   ep_guid as guid
   FROM appleEpisodeDetails
   LEFT JOIN appleEpisodeMetadata USING (episode_id)
+  WHERE aed_date >= @start AND aed_date <= @end
 )
 
 SELECT 
@@ -41,5 +43,6 @@ apple.quarter4 as apple_quarter4,
 spotify.listeners+apple.listeners as listeners_combined,
 apple.listeners as apple_listeners,
 spotify.listeners as spotify_listeners
-FROM spotify JOIN apple ON spotify.raw_name = apple.raw_name
+FROM spotify JOIN apple ON (spotify.raw_name = apple.raw_name AND aed_date=spp_date)
+-- make sure we have data from spotify and apple
 WHERE apple.quarter1 IS NOT NULL AND spotify.quarter1 IS NOT NULL

--- a/db_schema/schema.sql
+++ b/db_schema/schema.sql
@@ -74,6 +74,8 @@ CREATE TABLE IF NOT EXISTS spotifyPodcastAggregate (
 CREATE TABLE IF NOT EXISTS spotifyEpisodePerformance (
   account_id INTEGER NOT NULL,
   episode_id VARCHAR(128) NOT NULL,
+  -- CURRENT_DATE not supported in MySQL < 8 and planetscale
+  spp_date DATE NOT NULL DEFAULT CURRENT_DATE,
   spp_median_percentage TINYINT unsigned NOT NULL DEFAULT '0',
   spp_median_seconds MEDIUMINT unsigned NOT NULL DEFAULT '0',
   spp_percentile_25 TINYINT unsigned NOT NULL DEFAULT '0',

--- a/db_schema/schema.sql
+++ b/db_schema/schema.sql
@@ -145,6 +145,8 @@ CREATE TABLE IF NOT EXISTS appleEpisodeMetadata (
 CREATE TABLE IF NOT EXISTS appleEpisodeDetails (
   account_id INTEGER NOT NULL,
   episode_id BIGINT NOT NULL,
+  -- CURRENT_DATE not supported in MySQL < 8 and planetscale
+  aed_date DATE NOT NULL DEFAULT CURRENT_DATE,
   aed_playscount INTEGER NOT NULL,
   aed_totaltimelistened BIGINT NOT NULL,
   aed_uniqueengagedlistenerscount INTEGER NOT NULL,

--- a/src/db/AppleRepository.ts
+++ b/src/db/AppleRepository.ts
@@ -13,6 +13,21 @@ class AppleRepository {
         this.pool = pool
     }
 
+    getTodayDBString(): string {
+        const today = new Date()
+
+        // format to YYYY-mm-dd
+        // Note that today.toLocaleDateString('en-CA') returned `DD/MM/YYYY` on
+        // some systems
+        return (
+            today.getFullYear() +
+            '-' +
+            (today.getMonth() + 1) +
+            '-' +
+            today.getDate()
+        )
+    }
+
     // store metadata of multiple episodes
     async storeEpisodesMetadata(
         accountId: number,
@@ -62,6 +77,7 @@ class AppleRepository {
         const replaceStmt = `REPLACE INTO appleEpisodeDetails (
             account_id,
             episode_id,
+            aed_date,
             aed_playscount,
             aed_totaltimelistened,
             aed_uniqueengagedlistenerscount,
@@ -76,11 +92,12 @@ class AppleRepository {
             aed_quarter3_median_listeners,
             aed_quarter4_median_listeners
             ) VALUES
-            (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
+            (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
 
         return await this.pool.query(replaceStmt, [
             accountId,
             episodeId,
+            this.getTodayDBString(),
             episodeDetails.episodePlayCountAllTime.playscount,
             episodeDetails.episodePlayCountAllTime.totaltimelistened,
             episodeDetails.episodePlayCountAllTime.uniqueengagedlistenerscount,

--- a/src/db/SpotifyRepository.ts
+++ b/src/db/SpotifyRepository.ts
@@ -133,6 +133,7 @@ class SpotifyRepository {
         const replaceStmt = `REPLACE INTO spotifyEpisodePerformance (
                 account_id,
                 episode_id,
+                spp_date,
                 spp_median_percentage,
                 spp_median_seconds,
                 spp_percentile_25,
@@ -143,11 +144,12 @@ class SpotifyRepository {
                 spp_sample_max,
                 spp_sample_seconds,
                 spp_samples) VALUES
-                (?,?,?,?,?,?,?,?,?,?,?,?)
+                (?,?,?,?,?,?,?,?,?,?,?,?,?)
             `
         return await this.pool.query(replaceStmt, [
             accountId,
             episodeId,
+            this.getTodayDBString(),
             data.medianCompletion.percentage,
             data.medianCompletion.seconds,
             data.percentiles['25'],


### PR DESCRIPTION
- adds a date field to store a history of perofmance/LTR data (apple + spotify).
- API adapted to support start/end date requests on the LTR API

!BEFORE MERGE: merge SQL schema https://app.planetscale.com/services-openpodcast/openpodcast/deploy-requests/38 and alter tables on MySQL instances of customers.

fix #72