### PR TITLE
store provider in status updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ status: ## Send status request
 
 .PHONY: send-api-req-local
 send-api-req-local: ## Send a request to the local running server
-	curl -X POST http://localhost:8080/events -H 'Content-Type: application/json' -H 'Authorization: Bearer dummy-cn389ncoiwuencr' --data-binary "@./fixtures/forwarder.json" 
+	curl -X POST http://localhost:8080/connector -H 'Content-Type: application/json' -H 'Authorization: Bearer dummy-cn389ncoiwuencr' --data-binary "@./fixtures/spotifyPerformance.json" 
 
 .PHONY: send-analytics-req-local
 send-analytics-req-local: ## Send analytics request to the local running server
@@ -81,7 +81,7 @@ send-analytics-req-local: ## Send analytics request to the local running server
 
 .PHONY: send-api-req-prod
 send-api-req-prod: ## Send request to production
-	curl -X POST https://api.openpodcast.dev/connector  -H 'Content-Type: application/json' -H 'Authorization: Bearer dummy-cn389ncoiwuencr' --data-binary "@./fixtures/spotifyListeners.json" 
+	curl -X POST https://api.openpodcast.dev/connector  -H 'Content-Type: application/json' -H 'Authorization: Bearer dummy-cn389ncoiwuencr' --data-binary "@./fixtures/spotifyPerformance.json" 
 
 .PHONY: db-shell
 db-shell: ## Opens the mysql shell inside the db container

--- a/db_schema/migrations/3_updates_provider.sql
+++ b/db_schema/migrations/3_updates_provider.sql
@@ -1,0 +1,2 @@
+-- add column to store provider when inserting data
+ALTER TABLE updates ADD COLUMN provider VARCHAR(64) NOT NULL DEFAULT 'unknown' AFTER account_id;

--- a/db_schema/schema.sql
+++ b/db_schema/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS migrations (
 -- -----------------------------------------
 -- IMPORTANT: this is the schema version
 -- ID has to be incremented for each change
-INSERT INTO migrations (migration_id, migration_name) VALUES (2, 'anchor support');
+INSERT INTO migrations (migration_id, migration_name) VALUES (3, 'updates_provider');
 -- -----------------------------------------
 
 CREATE TABLE IF NOT EXISTS events (
@@ -254,6 +254,7 @@ CREATE TABLE IF NOT EXISTS feedbackComment (
 -- contains JSON with the update data
 CREATE TABLE IF NOT EXISTS updates (
   account_id INTEGER NOT NULL,
+  provider VARCHAR(64) NOT NULL,
   endpoint VARCHAR(64) NOT NULL,
   created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   update_data JSON NOT NULL,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
             - MYSQL_PASSWORD=openpodcast
             - MYSQL_DATABASE=openpodcast
             - MYSQL_PORT=3306
-            - ACCOUNTS='{"dummy-cn389ncoiwuencr":1}'
+            - ACCOUNTS={"dummy-cn389ncoiwuencr":1}
         ports:
             - '8080:8080'
         links:

--- a/src/db/StatusRepository.ts
+++ b/src/db/StatusRepository.ts
@@ -40,7 +40,7 @@ class StatusRepository {
     //     }
     // }
     async getStatus(): Promise<Status> {
-        const query = `SELECT account_id, endpoint, MAX(created) AS latest_update FROM updates GROUP BY account_id, endpoint`
+        const query = `SELECT account_id, provider, endpoint, MAX(created) AS latest_update FROM updates GROUP BY account_id, provider, endpoint`
         const response = (await this.pool.query(query)) as RowDataPacket[]
 
         // Response should have at least one row.
@@ -58,7 +58,9 @@ class StatusRepository {
                 }
             }
 
-            status[row.account_id].latestUpdates[row.endpoint] = new Date(
+            const identifier = `${row.provider}/${row.endpoint}`
+
+            status[row.account_id].latestUpdates[identifier] = new Date(
                 row.latest_update
             )
         })

--- a/src/db/StatusRepository.ts
+++ b/src/db/StatusRepository.ts
@@ -69,9 +69,10 @@ class StatusRepository {
     // Write the raw JSON status data into the `updates` table
     // Use the current timestamp as the update time
     async updateStatus(accountId: number, update: StatusPayload): Promise<any> {
-        const query = `REPLACE INTO updates (account_id, endpoint, update_data) VALUES (?, ?, ?)`
+        const query = `REPLACE INTO updates (account_id, provider, endpoint, update_data) VALUES (?,?,?,?)`
         return await this.pool.query(query, [
             accountId,
+            update.provider,
             update.endpoint,
             JSON.stringify(update.data),
         ])

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,8 +383,8 @@ app.post('/connector', (async (
 
         // Construct a payload for event sourcing
         res.locals.update = {
+            provider: connectorPayload.provider,
             endpoint: connectorPayload.meta.endpoint,
-            // TODO: Which data should be stored?
             data: connectorPayload,
         }
     } catch (err) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -21,6 +21,7 @@ export class AuthError extends HttpError {
 }
 
 export interface StatusPayload {
+    provider: string
     endpoint: string
     data: Object
 }


### PR DESCRIPTION
stores provider in updates table ad some endpoints might exist for multiple providers

- adds field to DB
- executes needed migrations
- changes status page to include provider as well

fix #99

warning: as a migration was added, it might affect the migration number of still open PRs that include migrations
