### PR TITLE
`podcastEpisodeITunesTitle` is not required

### DIFF
--- a/src/schema/apple/episodes.json
+++ b/src/schema/apple/episodes.json
@@ -87,7 +87,6 @@
                 "name",
                 "collectionName",
                 "podcastEpisodeGuid",
-                "podcastEpisodeITunesTitle",
                 "podcastEpisodeType",
                 "releaseDateTime",
                 "releaseDate",


### PR DESCRIPTION
Fixes an issue reported in https://github.com/openpodcast/api/issues/119#issuecomment-1624422002