### PR TITLE
Anchor Report Query Changes

### DIFF
--- a/db_schema/queries/v1/reportAnchorTotalPlaysByEpisode.sql
+++ b/db_schema/queries/v1/reportAnchorTotalPlaysByEpisode.sql
@@ -1,0 +1,27 @@
+WITH last_date AS (
+    SELECT 
+        MAX(date) AS max_date
+    FROM 
+        anchorTotalPlaysByEpisode
+    WHERE
+        date >= @start
+        AND date <= @end
+        AND account_id = @podcast_id
+)
+SELECT
+    a.account_id,
+    a.date,
+    e.episode_id,
+    a.plays
+FROM
+    anchorTotalPlaysByEpisode AS a
+JOIN 
+    last_date AS b ON a.date = b.max_date
+JOIN 
+    -- We join on the episode title because to get the episode ID the Anchor API
+    -- does not provide episode IDs in the raw episode plays data
+    anchorPodcastEpisodes AS e ON a.account_id = e.account_id AND a.episode_id = e.title
+WHERE
+    a.account_id = @podcast_id
+ORDER BY 
+    a.date ASC;


### PR DESCRIPTION
Required for https://github.com/openpodcast/report/pull/17.

The `reportAnchorPlays` query was modified, but it wasn't used
by the report in its old form.