### PR TITLE
Fix Anchor Episode ID handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ shell-% sh-%: ## Run a shell in a container
 test: ## Run tests
 	npx jest ./src --verbose true
 
+.PHONY: integration-test
+integration-test: ## Run integration tests locally
+	npx jest ./tests/api_e2e --verbose true
+
 .PHONY: e2e-tests
 e2e-tests: ## Start end2end tests
 	@make up &

--- a/db_schema/migrations/11_anchor_episodes_page.sql
+++ b/db_schema/migrations/11_anchor_episodes_page.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS anchorEpisodesPage (
+  account_id INTEGER NOT NULL,
+  episode_id VARCHAR(128) NOT NULL,
+  web_episode_id VARCHAR(128) NOT NULL,
+  PRIMARY KEY (account_id, episode_id, web_episode_id)
+);
+
+-- Add a secondary index to resolve the web_episode_id to the episode_id
+CREATE INDEX idx_account_episode ON anchorEpisodesPage(account_id, web_episode_id, episode_id);
+
+INSERT INTO migrations (migration_id, migration_name) VALUES (11, 'anchor episodesPage');

--- a/db_schema/schema.sql
+++ b/db_schema/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS migrations (
 -- -----------------------------------------
 -- IMPORTANT: this is the schema version
 -- ID has to be incremented for each change
-INSERT INTO migrations (migration_id, migration_name) VALUES (10, 'voting agent');
+INSERT INTO migrations (migration_id, migration_name) VALUES (11, 'anchor episodesPage');
 -- -----------------------------------------
 
 CREATE TABLE IF NOT EXISTS events (
@@ -529,6 +529,16 @@ INSERT INTO appleCountries (id, name, code, ccc) VALUES (4, "Afghanistan", "AF",
 (887, "Yemen", "YE", "yem"),
 (894, "Zambia", "ZM", "zmb"),
 (716, "Zimbabwe", "ZW", "zwe");
+
+CREATE TABLE IF NOT EXISTS anchorEpisodesPage (
+  account_id INTEGER NOT NULL,
+  episode_id VARCHAR(128) NOT NULL,
+  web_episode_id VARCHAR(128) NOT NULL,
+  PRIMARY KEY (account_id, episode_id, web_episode_id)
+);
+
+-- Add a secondary index to resolve the web_episode_id to the episode_id
+CREATE INDEX idx_account_episode ON anchorEpisodesPage(account_id, web_episode_id, episode_id);
 
 CREATE TABLE IF NOT EXISTS anchorAudienceSize (
   account_id INTEGER NOT NULL,

--- a/fixtures/anchorEpisodeAggregatedPerformance.json
+++ b/fixtures/anchorEpisodeAggregatedPerformance.json
@@ -5,7 +5,9 @@
   "meta": {
     "show": "123abcde",
     "endpoint": "aggregatedPerformance",
-    "episode": "foo1234"
+    "episode": "e215pm4",
+    "episodeIdNum": 67347588,
+    "webEpisodeId": "e215pm4"
   },
   "range": {
     "start": "2023-05-01",

--- a/fixtures/anchorEpisodePerformance.json
+++ b/fixtures/anchorEpisodePerformance.json
@@ -5,7 +5,9 @@
   "meta": {
     "show": "123abcde",
     "endpoint": "episodePerformance",
-    "episode": "foo1234"
+    "episode": "e215pm4",
+    "episodeIdNum": 67347588,
+    "webEpisodeId": "e215pm4"
   },
   "range": {
     "start": "2023-05-01",

--- a/fixtures/anchorEpisodePlays.json
+++ b/fixtures/anchorEpisodePlays.json
@@ -5,7 +5,9 @@
   "meta": {
     "show": "123abcde",
     "endpoint": "episodePlays",
-    "episode": "foo1234"
+    "episode": "e215pm4",
+    "episodeIdNum": 67347588,
+    "webEpisodeId": "e215pm4"
   },
   "range": {
     "start": "2023-05-01",

--- a/fixtures/anchorEpisodesPage.json
+++ b/fixtures/anchorEpisodesPage.json
@@ -1,0 +1,53 @@
+{
+  "provider": "anchor",
+  "version": 1,
+  "retrieved": "2023-08-10T19:39:06.669275",
+  "meta": {
+    "show": "81d85ec4",
+    "endpoint": "episodesPage"
+  },
+  "range": {
+    "start": "2023-07-11",
+    "end": "2023-08-09"
+  },
+  "data": [
+    {
+      "episodeId": 68984665,
+      "webEpisodeId": "e22nocn",
+      "title": "A nice long title for this episode",
+      "publishOnUnixTimestamp": 1682051448,
+      "createdUnixTimestamp": 1682003412,
+      "shareLinkPath": "/john-doe/episodes/something-e22nocn",
+      "shareLinkEmbedPath": "/john-doe/embed/episodes/something-e22nocn",
+      "downloadUrl": "/pod/api/audio/a9mulu1/download?url=https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%xxxx-3-20%2F325064065-44100-2-a7431192eb7f5.m4a",
+      "totalPlays": 123,
+      "duration": 2539933,
+      "adCount": 0,
+      "containsMusicSegments": false,
+      "isPublishedToSpotifyExclusively": false,
+      "wordpressPostMetadataId": null,
+      "isTrailer": false,
+      "isVideoEpisode": true,
+      "audioCount": 1
+    },
+    {
+      "episodeId": 67347583,
+      "webEpisodeId": "e215pm4",
+      "title": "A nice long title for this episode 2",
+      "publishOnUnixTimestamp": 1680238808,
+      "createdUnixTimestamp": 1679848799,
+      "shareLinkPath": "/john-doe/episodes/something-e215pm4",
+      "shareLinkEmbedPath": "/john-doe/embed/episodes/something-e215pm4",
+      "downloadUrl": "/pod/api/audio/a9ifueq/download?url=https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%XXXXXX-2-26%2F320386970-44100-2-5325b64168e6d.m4a",
+      "totalPlays": 240,
+      "duration": 3211018,
+      "adCount": 0,
+      "containsMusicSegments": false,
+      "isPublishedToSpotifyExclusively": false,
+      "wordpressPostMetadataId": null,
+      "isTrailer": false,
+      "isVideoEpisode": true,
+      "audioCount": 1
+    }
+  ]
+}

--- a/fixtures/anchorPodcastEpisode.json
+++ b/fixtures/anchorPodcastEpisode.json
@@ -12,7 +12,7 @@
   },
   "data": {
     "allEpisodeWebIds": [
-      "foo1234"
+      "e215pm4"
     ],
     "podcastId": "123abcde",
     "podcastEpisodes": [
@@ -25,14 +25,14 @@
         "hourOffset": -2,
         "isDeleted": false,
         "isPublished": true,
-        "podcastEpisodeId": "foo1234",
+        "podcastEpisodeId": "e215pm4",
         "publishOn": "2023-04-21T04:30:48.000Z",
         "publishOnUnixTimestamp": 1682051448000,
         "title": "Title 0",
         "url": "https://s3-us-west-2.amazonaws.com/anchor-audio-bank/staging/2023-1-01/392204921-22100-1-6f1f1cdebd586.mp3",
         "trackedUrl": "https://anchor.fm/s/undefined/podcast/play/undefined/undefined",
         "episodeImage": null,
-        "shareLinkPath": "/john-doe/episodes/Self-serve-analytics-powered-by-GPT-4-w-David-Jayatillake-foo1234",
+        "shareLinkPath": "/john-doe/episodes/Self-serve-analytics-powered-by-GPT-4-w-David-Jayatillake-e215pm4",
         "shareLinkEmbedPath": "/john-doe/embed/episodes/Self-serve-analytics-powered-by-GPT-4-w-David-Jayatillake-foo1234"
       }
     ],

--- a/src/api/connectors/AnchorConnector.ts
+++ b/src/api/connectors/AnchorConnector.ts
@@ -5,6 +5,7 @@ import audienceSizeSchema from '../../schema/anchor/audienceSize.json'
 import aggregatedPerformanceSchema from '../../schema/anchor/aggregatedPerformance.json'
 import episodePerformanceSchema from '../../schema/anchor/episodePerformance.json'
 import episodePlaysSchema from '../../schema/anchor/episodePlays.json'
+import episodesPageSchema from '../../schema/anchor/episodesPage.json'
 import playsSchema from '../../schema/anchor/plays.json'
 import playsByAgeRangeSchema from '../../schema/anchor/playsByAgeRange.json'
 import playsByAppSchema from '../../schema/anchor/playsByApp.json'
@@ -35,6 +36,7 @@ import {
     RawAnchorTotalPlaysData,
     RawAnchorTotalPlaysByEpisodeData,
     RawAnchorUniqueListenersData,
+    RawAnchorEpisodesPageData,
 } from '../../types/provider/anchor'
 import { AnchorRepository } from '../../db/AnchorRepository'
 import { isArray } from 'mathjs'
@@ -104,6 +106,11 @@ class AnchorConnector implements ConnectorHandler {
                 payload.meta.episode,
                 payload.data.data as RawAnchorAggregatedPerformanceData
             )
+        } else if (endpoint == 'episodesPage') {
+            validateJsonApiPayload(episodesPageSchema, rawPayload)
+            const data = payload.data as RawAnchorEpisodesPageData[]
+            // episodeId and webEpisodeId are part of the `data` payload
+            await this.repo.storeEpisodesPage(accountId, data)
         } else if (endpoint == 'episodePerformance') {
             validateJsonApiPayload(episodePerformanceSchema, rawPayload)
             if (payload.meta.episode === undefined) {

--- a/src/schema/anchor/episodesPage.json
+++ b/src/schema/anchor/episodesPage.json
@@ -1,0 +1,129 @@
+{
+    "$id": "http://openpodcast.dev/schema/anchor/episodesPage.schema.json",
+    "title": "List of all episodes including basic information per episode",
+    "type": "object",
+    "properties": {
+        "provider": {
+            "type": "string"
+        },
+        "version": {
+            "type": "number"
+        },
+        "retrieved": {
+            "type": "string"
+        },
+        "meta": {
+            "type": "object",
+            "properties": {
+                "show": {
+                    "type": "string"
+                },
+                "endpoint": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "show",
+                "endpoint"
+            ]
+        },
+        "range": {
+            "type": "object",
+            "properties": {
+                "start": {
+                    "type": "string"
+                },
+                "end": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "start",
+                "end"
+            ]
+        },
+        "data": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "episodeId": {
+                        "type": "number"
+                    },
+                    "webEpisodeId": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "publishOnUnixTimestamp": {
+                        "type": "number"
+                    },
+                    "createdUnixTimestamp": {
+                        "type": "number"
+                    },
+                    "shareLinkPath": {
+                        "type": "string"
+                    },
+                    "shareLinkEmbedPath": {
+                        "type": "string"
+                    },
+                    "downloadUrl": {
+                        "type": "string"
+                    },
+                    "totalPlays": {
+                        "type": "number"
+                    },
+                    "duration": {
+                        "type": "number"
+                    },
+                    "adCount": {
+                        "type": "number"
+                    },
+                    "containsMusicSegments": {
+                        "type": "boolean"
+                    },
+                    "isPublishedToSpotifyExclusively": {
+                        "type": "boolean"
+                    },
+                    "wordpressPostMetadataId": {},
+                    "isTrailer": {
+                        "type": "boolean"
+                    },
+                    "isVideoEpisode": {
+                        "type": "boolean"
+                    },
+                    "audioCount": {
+                        "type": "number"
+                    }
+                },
+                "required": [
+                    "episodeId",
+                    "webEpisodeId",
+                    "title",
+                    "publishOnUnixTimestamp",
+                    "createdUnixTimestamp",
+                    "shareLinkPath",
+                    "shareLinkEmbedPath",
+                    "downloadUrl",
+                    "totalPlays",
+                    "duration",
+                    "adCount",
+                    "containsMusicSegments",
+                    "isPublishedToSpotifyExclusively",
+                    "wordpressPostMetadataId",
+                    "isTrailer",
+                    "audioCount"
+                ]
+            }
+        }
+    },
+    "required": [
+        "provider",
+        "version",
+        "retrieved",
+        "meta",
+        "range",
+        "data"
+    ]
+}

--- a/src/types/provider/anchor.ts
+++ b/src/types/provider/anchor.ts
@@ -222,6 +222,7 @@ export interface AnchorConnectorPayload {
 type AnchorConnectorPayloadData =
     | (AnchorDataPayload & { stationId: string })
     | RawAnchorPodcastData
+    | RawAnchorEpisodesPageData[]
 
 export interface RawAnchorEpisodeData {
     adCount: number
@@ -250,4 +251,29 @@ export interface RawAnchorPodcastData {
     totalPodcastEpisodes: number
     vanitySlug: string
     stationCreatedDate: string
+}
+
+// This type is similar to `RawAnchorEpisodeData`,
+// but it's used by the `EpisodesPage` API endpoint.
+// We are only interested in the `episodeId` and `webEpisodeId` fields.
+// The rest of the data is either not relevant or is fetched from other
+// endpoints.
+export interface RawAnchorEpisodesPageData {
+    episodeId: number
+    webEpisodeId: string
+    title: string
+    publishOnUnixTimestamp: number
+    createdUnixTimestamp: number
+    shareLinkPath: string
+    shareLinkEmbedPath: string
+    downloadUrl: string
+    totalPlays: number
+    duration: number
+    adCount: number
+    containsMusicSegments: boolean
+    isPublishedToSpotifyExclusively: boolean
+    wordpressPostMetadataId: null | number
+    isTrailer: boolean
+    isVideoEpisode?: boolean
+    audioCount: number
 }

--- a/tests/api_e2e/anchor.test.js
+++ b/tests/api_e2e/anchor.test.js
@@ -15,6 +15,7 @@ const anchorPodcastEpisodePayload = require('../../fixtures/anchorPodcastEpisode
 const anchorTotalPlaysPayload = require('../../fixtures/anchorTotalPlays.json')
 const anchorTotalPlaysByEpisodePayload = require('../../fixtures/anchorTotalPlaysByEpisode.json')
 const anchorUniqueListenersPayload = require('../../fixtures/anchorUniqueListeners.json')
+const anchorEpisodesPagePayload = require('../../fixtures/anchorEpisodesPage.json')
 
 const auth = require('./authheader')
 
@@ -203,6 +204,17 @@ describe('check Connector API with anchorUniqueListenersPayload', () => {
             .post('/connector')
             .set(auth)
             .send(anchorUniqueListenersPayload)
+        expect(response.statusCode).toBe
+        expect(response.statusCode).toBe(200)
+    })
+})
+
+describe('check Connector API with anchorEpisodesPagePayload', () => {
+    it('should return status 200 when sending proper Anchor payload', async () => {
+        const response = await request(baseURL)
+            .post('/connector')
+            .set(auth)
+            .send(anchorEpisodesPagePayload)
         expect(response.statusCode).toBe
         expect(response.statusCode).toBe(200)
     })


### PR DESCRIPTION
Updates the fixtures and code for Anchor episode ID handling
as we've been inconsistent with the episode IDs we use.
There are actually two IDs: episodeId and webEpisodeId,
for which we sometimes need a mapping between the two.
This PR fixes that.