### PR TITLE
Update query after fixing episode IDs in Anchor

### DIFF
--- a/db_schema/queries/v1/reportAnchorTotalPlaysByEpisode.sql
+++ b/db_schema/queries/v1/reportAnchorTotalPlaysByEpisode.sql
@@ -11,19 +11,16 @@ WITH last_date AS (
 SELECT
     a.account_id,
     a.date,
-    e.episode_id,
+    e.web_episode_id as episode_id,
     a.plays
 FROM
     anchorTotalPlaysByEpisode AS a
 JOIN 
     last_date AS b ON a.date = b.max_date
 JOIN 
-    -- We join on the episode title because to get the episode ID the Anchor API
-    -- does not provide episode IDs in the raw episode plays data
-    -- TODO: THIS IS WRONG
-    -- episode_id contains an int which is the podcast_id in anchorTotalPlaysByEpisode
-    anchorPodcastEpisodes AS e ON a.account_id = e.account_id AND a.episode_id = e.title
+    anchorEpisodesPage e ON a.account_id = e.account_id AND a.episode_id = e.episode_id
 WHERE
     a.account_id = @podcast_id
 ORDER BY 
     a.date ASC;
+   


### PR DESCRIPTION
Related to https://github.com/openpodcast/api/pull/130.
We can now use the proper anchor episode IDs in the report and don't have to use the title anymore for the mapping.