### PR TITLE
Improve error logging for unknown routes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -403,7 +403,7 @@ app.get(
 
 // catch 404 and forward to error handler
 app.use(function (req: Request, res: Response, next: NextFunction) {
-    const err = new HttpError('Not Found')
+    const err = new HttpError(`Not Found: ${req.originalUrl}`)
     err.status = 404
     next(err)
 })

--- a/tests/api_e2e/basic_api_calls.test.js
+++ b/tests/api_e2e/basic_api_calls.test.js
@@ -39,3 +39,14 @@ describe('check Connector API error cases', () => {
         expect(response.statusCode).toBe(400)
     })
 })
+
+describe('check Connector API error cases', () => {
+    it('should return status 404 and print missing route when requesting invalid route', async () => {
+        const response = await request(baseURL)
+            .post('/unknown')
+            .set(auth)
+            .send({ endpoint: 'unknown' })
+        expect(response.statusCode).toBe(404)
+        expect(response.text).toContain('Not Found: /unknown')
+    })
+})


### PR DESCRIPTION
There are a few error messages in our logs about unknown
routes. In order to to gain some visibility into which routes
get requested (and could be blacklisted), we can log the
original URL that was requested.