### PR TITLE
Adjust Queries to Handle Incomplete Date Range Data

### DIFF
--- a/db_schema/queries/v1/reportApplePodcastBaseMetrics.sql
+++ b/db_schema/queries/v1/reportApplePodcastBaseMetrics.sql
@@ -36,7 +36,7 @@ followers_end AS (
     AND account_id = @podcast_id
 )
 SELECT
-  podcast_id,
+  plays.podcast_id,
   apple_playscount,
   apple_totaltimelistened, -- in seconds
   apple_uniqueengagedlistenerscount,
@@ -44,6 +44,7 @@ SELECT
   followers_start.apple_followers as apple_followers_start,
   followers_end.apple_followers as apple_followers_end
 FROM
-  plays JOIN followers_start USING (podcast_id)
-  JOIN followers_end USING (podcast_id)
+  plays 
+LEFT JOIN followers_start ON plays.podcast_id = followers_start.podcast_id
+LEFT JOIN followers_end ON plays.podcast_id = followers_end.podcast_id
 

--- a/db_schema/queries/v1/reportApplePodcastBaseMetrics.sql
+++ b/db_schema/queries/v1/reportApplePodcastBaseMetrics.sql
@@ -22,8 +22,10 @@ followers_start AS (
   FROM
     appleTrendsPodcastFollowers
   WHERE
-    atf_date = @start
-    AND account_id = @podcast_id 
+    atf_date BETWEEN @start AND @end
+    AND account_id = @podcast_id
+  ORDER BY atf_date ASC
+  LIMIT 1
 ),
 followers_end AS (
   SELECT
@@ -32,8 +34,10 @@ followers_end AS (
   FROM
     appleTrendsPodcastFollowers
   WHERE
-    atf_date = @end
+    atf_date BETWEEN @start AND @end
     AND account_id = @podcast_id
+  ORDER BY atf_date DESC
+  LIMIT 1
 )
 SELECT
   plays.podcast_id,

--- a/db_schema/queries/v1/reportSpotifyPodcastBaseMetrics.sql
+++ b/db_schema/queries/v1/reportSpotifyPodcastBaseMetrics.sql
@@ -32,12 +32,12 @@ followers_end AS (
     AND account_id = @podcast_id 
 )
 SELECT
-  podcast_id,
+  streams.podcast_id,
   spotify_starts,
   spotify_streams,
   followers_start.spotify_followers as spotify_followers_start,
   followers_end.spotify_followers as spotify_followers_end
 FROM
-  streams JOIN followers_start USING (podcast_id)
-  JOIN followers_end USING (podcast_id)
-
+  streams 
+LEFT JOIN followers_start ON streams.podcast_id = followers_start.podcast_id
+LEFT JOIN followers_end ON streams.podcast_id = followers_end.podcast_id

--- a/db_schema/queries/v1/reportSpotifyPodcastBaseMetrics.sql
+++ b/db_schema/queries/v1/reportSpotifyPodcastBaseMetrics.sql
@@ -18,8 +18,10 @@ followers_start AS (
   FROM
     spotifyPodcastFollowers
   WHERE
-    spf_date = @start
+    spf_date BETWEEN @start AND @end
     AND account_id = @podcast_id 
+  ORDER BY spf_date ASC
+  LIMIT 1
 ),
 followers_end AS (
   SELECT
@@ -28,8 +30,10 @@ followers_end AS (
   FROM
     spotifyPodcastFollowers
   WHERE
-    spf_date = @end
+    spf_date BETWEEN @start AND @end
     AND account_id = @podcast_id 
+  ORDER BY spf_date DESC
+  LIMIT 1
 )
 SELECT
   streams.podcast_id,

--- a/db_schema/queries/v1/reportSpotifyUniqueListeners.sql
+++ b/db_schema/queries/v1/reportSpotifyUniqueListeners.sql
@@ -1,29 +1,48 @@
 WITH episodeListeners as
-(SELECT
+(
+  SELECT
     account_id,
     SUM(n.epm_listeners-o.epm_listeners) as listeners
-FROM
-  spotifyEpisodeMetadataHistory o JOIN spotifyEpisodeMetadataHistory n USING (account_id, episode_id)
-WHERE 
-  o.epm_date = @start
-  AND n.epm_date = @end
-  AND account_id = @podcast_id
-GROUP BY account_id
+  FROM
+    spotifyEpisodeMetadataHistory o 
+    JOIN spotifyEpisodeMetadataHistory n USING (account_id, episode_id)
+  WHERE 
+    o.epm_date BETWEEN @start AND @end
+    AND n.epm_date BETWEEN @start AND @end
+    AND account_id = @podcast_id
+  GROUP BY account_id
 ),
-podcastListeners as
-(SELECT
+podcastListenersStart as
+(
+  SELECT
     account_id,
     n.spm_listeners-o.spm_listeners as listeners
-FROM
-    spotifyPodcastMetadata o JOIN spotifyPodcastMetadata n USING (account_id)
-WHERE
-    o.spm_date = @start
-    AND n.spm_date = @end
+  FROM
+    spotifyPodcastMetadata o 
+    JOIN spotifyPodcastMetadata n USING (account_id)
+  WHERE
+    o.spm_date BETWEEN @start AND @end
     AND account_id = @podcast_id
-LIMIT 1
+  ORDER BY o.spm_date ASC
+  LIMIT 1
+),
+podcastListenersEnd as
+(
+  SELECT
+    account_id,
+    n.spm_listeners-o.spm_listeners as listeners
+  FROM
+    spotifyPodcastMetadata o 
+    JOIN spotifyPodcastMetadata n USING (account_id)
+  WHERE
+    n.spm_date BETWEEN @start AND @end
+    AND account_id = @podcast_id
+  ORDER BY n.spm_date DESC
+  LIMIT 1
 )
 SELECT
-    account_id,
-    episodeListeners.listeners as unique_podcast_listens,
-    podcastListeners.listeners as new_unique_podcast_listeners
-FROM episodeListeners JOIN podcastListeners USING (account_id)
+    e.account_id,
+    e.listeners as unique_podcast_listens,
+    p.listeners as new_unique_podcast_listeners
+FROM episodeListeners e 
+JOIN podcastListenersEnd p USING (account_id)

--- a/db_schema/queries/v1/reportSpotifyUniqueListeners.sql
+++ b/db_schema/queries/v1/reportSpotifyUniqueListeners.sql
@@ -1,48 +1,34 @@
-WITH episodeListeners as
+WITH episodeListeners AS
 (
-  SELECT
-    account_id,
-    SUM(n.epm_listeners-o.epm_listeners) as listeners
-  FROM
-    spotifyEpisodeMetadataHistory o 
+    SELECT
+        account_id,
+        SUM(n.epm_listeners - o.epm_listeners) as listeners
+    FROM
+        spotifyEpisodeMetadataHistory o
     JOIN spotifyEpisodeMetadataHistory n USING (account_id, episode_id)
-  WHERE 
-    o.epm_date BETWEEN @start AND @end
-    AND n.epm_date BETWEEN @start AND @end
-    AND account_id = @podcast_id
-  GROUP BY account_id
+    WHERE 
+        o.epm_date = (SELECT MAX(epm_date) FROM spotifyEpisodeMetadataHistory WHERE epm_date <= @start AND account_id = @podcast_id)
+        AND n.epm_date = (SELECT MAX(epm_date) FROM spotifyEpisodeMetadataHistory WHERE epm_date <= @end AND account_id = @podcast_id)
+        AND o.account_id = @podcast_id
+    GROUP BY o.account_id
 ),
-podcastListenersStart as
+podcastListeners AS
 (
-  SELECT
-    account_id,
-    n.spm_listeners-o.spm_listeners as listeners
-  FROM
-    spotifyPodcastMetadata o 
+    SELECT
+        account_id,
+        n.spm_listeners - o.spm_listeners as listeners
+    FROM
+        spotifyPodcastMetadata o
     JOIN spotifyPodcastMetadata n USING (account_id)
-  WHERE
-    o.spm_date BETWEEN @start AND @end
-    AND account_id = @podcast_id
-  ORDER BY o.spm_date ASC
-  LIMIT 1
-),
-podcastListenersEnd as
-(
-  SELECT
-    account_id,
-    n.spm_listeners-o.spm_listeners as listeners
-  FROM
-    spotifyPodcastMetadata o 
-    JOIN spotifyPodcastMetadata n USING (account_id)
-  WHERE
-    n.spm_date BETWEEN @start AND @end
-    AND account_id = @podcast_id
-  ORDER BY n.spm_date DESC
-  LIMIT 1
+    WHERE
+        o.spm_date = (SELECT MAX(spm_date) FROM spotifyPodcastMetadata WHERE spm_date <= @start AND account_id = @podcast_id)
+        AND n.spm_date = (SELECT MAX(spm_date) FROM spotifyPodcastMetadata WHERE spm_date <= @end AND account_id = @podcast_id)
+        AND o.account_id = @podcast_id
+    LIMIT 1
 )
 SELECT
-    e.account_id,
-    e.listeners as unique_podcast_listens,
-    p.listeners as new_unique_podcast_listeners
-FROM episodeListeners e 
-JOIN podcastListenersEnd p USING (account_id)
+    account_id,
+    episodeListeners.listeners as unique_podcast_listens,
+    podcastListeners.listeners as new_unique_podcast_listeners
+FROM episodeListeners 
+JOIN podcastListeners USING (account_id)


### PR DESCRIPTION
The current SQL queries assume that we have data available precisely at the `@start` and `@end` dates. However, in some instances, we might not have data for these specific dates, even though there's data within that range. This results in unexpected empty datasets, potentially leading to incomplete or misleading reports.

Instead of relying strictly on `@start` and `@end` dates, the queries have been adjusted to fetch the earliest available data point after `@start` and the latest data point before `@end` within the specified date range.