### PR TITLE
get plays from single day data to avoid N/A data for newly added podcasts

### DIFF
--- a/db_schema/queries/v1/reportAnchorPlays.sql
+++ b/db_schema/queries/v1/reportAnchorPlays.sql
@@ -1,59 +1,17 @@
- 
 WITH 
-first_date AS (
-  SELECT 
-    MIN(date) as first_date
-  FROM 
-    anchorTotalPlays
-  WHERE 
-    date >= @start
-    AND date <= @end
-    AND account_id = @podcast_id
-),
-last_date AS (
-  SELECT 
-    MAX(date) as last_date
-  FROM 
-    anchorTotalPlays
-  WHERE 
-    date >= @start
-    AND date <= @end
-    AND account_id = @podcast_id
-),
-anchor_total_podcast AS (
-  SELECT 
-    account_id,
-    date,
-    plays 
-  FROM
-    anchorTotalPlays
-  WHERE
-    date >= @start
-    AND date <= @end
-    AND account_id = @podcast_id
-),
-first_day_plays AS (
-  SELECT
-    atp.plays as first_day_plays
-  FROM
-    anchor_total_podcast atp
-  JOIN
-    first_date fd
-  ON
-    atp.date = fd.first_date
-),
-last_day_plays AS (
-  SELECT
-    atp.plays as last_day_plays
-  FROM
-    anchor_total_podcast atp
-  JOIN
-    last_date ld
-  ON
-    atp.date = ld.last_date
+plays_in_period AS (
+  SELECT account_id, sum(plays) as period_plays FROM anchorPlays 
+  WHERE account_id = @podcast_id AND date BETWEEN @start AND @end
+  GROUP BY account_id
 )
 SELECT
-  ldp.last_day_plays as total_plays,
-  (ldp.last_day_plays - fdp.first_day_plays) as plays_within_period
+  plays as total_plays,
+  period_plays as plays_within_period
 FROM
-  first_day_plays fdp, last_day_plays ldp;
+  anchorTotalPlays JOIN plays_in_period USING (account_id)
+WHERE
+  account_id = @podcast_id
+  AND date BETWEEN @start AND @end
+  -- use the newest data available in the date range
+  ORDER BY date DESC
+  LIMIT 1;


### PR DESCRIPTION
instead of taking total plays and do some calc, we can just sum up all single days to get the plays in a specified period of time.