### PR TITLE
Update SQL variable handling

### DIFF
--- a/src/api/AnalyticsApi.ts
+++ b/src/api/AnalyticsApi.ts
@@ -28,7 +28,7 @@ class AnalyticsApi {
         }
 
         const sqlVars = {
-            podcast_id: podcastId,
+            podcast_id: parseInt(podcastId),
             start: formatDate(startDate),
             end: formatDate(endDate),
         }

--- a/src/db/AnalyticsRepository.ts
+++ b/src/db/AnalyticsRepository.ts
@@ -34,8 +34,6 @@ class AnalyticsRepository {
             query = query?.replaceAll(`@${key}`, escapedValue)
         }
 
-        console.log(query)
-
         // Execute the query and return the result
         const [rows, _] = await this.pool.query(query)
         return rows

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,6 @@ const pool = mysql.createPool({
     waitForConnections: true,
     connectionLimit: 10,
     queueLimit: 0,
-    multipleStatements: true,
     // do not touch dates and return native string representation
     // see https://github.com/mysqljs/mysql#connection-options
     dateStrings: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
     /* Language and Environment */
-    "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2021", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
At the beginning, we considered using MySQL's built-in variable system to replace `podcast_id`, and the `start/end` dates. The idea was to leverage the internal optimizer, which might have been capable of more efficient processing by recognizing these as variables. However, the outcome was the opposite. The optimizer became confused, leading to incorrect decisions that resulted in significantly longer query execution times—sometimes even resulting in timeouts of multiple minutes. This PR introduces variable replacement directly during SQL query generation on the client side, which should generally lead to faster execution times.