### PR TITLE
Add anchor impressions support with database schema and API integration

### DIFF
--- a/db_schema/migrations/12_anchor_impressions.sql
+++ b/db_schema/migrations/12_anchor_impressions.sql
@@ -1,0 +1,38 @@
+-- Create table for storing aggregate impression metrics
+CREATE TABLE IF NOT EXISTS anchorImpressions (
+    account_id INTEGER NOT NULL,
+    date_start TIMESTAMP NOT NULL,
+    date_end TIMESTAMP NOT NULL,
+    total_impressions INTEGER NOT NULL,
+    total_considerations INTEGER NOT NULL,
+    total_streams INTEGER NOT NULL,
+    considerations_conversion_rate DECIMAL(10,5),
+    streams_conversion_rate DECIMAL(10,5),
+    PRIMARY KEY (account_id, date_start, date_end)
+);
+
+-- Create table for daily impression data
+CREATE TABLE IF NOT EXISTS anchorImpressionsDaily (
+    account_id INTEGER NOT NULL,
+    date TIMESTAMP NOT NULL,
+    impressions INTEGER NOT NULL,
+    PRIMARY KEY (account_id, date)
+);
+
+-- Create table for impression sources breakdown
+CREATE TABLE IF NOT EXISTS anchorImpressionsSources (
+    account_id INTEGER NOT NULL,
+    date_start TIMESTAMP NOT NULL,
+    date_end TIMESTAMP NOT NULL,
+    source_id VARCHAR(32) NOT NULL,
+    source_name VARCHAR(64) NOT NULL,
+    impression_count INTEGER NOT NULL,
+    PRIMARY KEY (account_id, date_start, date_end, source_id)
+);
+
+-- Add index for querying date ranges efficiently
+CREATE INDEX idx_daily_impressions_date ON anchorImpressionsDaily(account_id, date);
+CREATE INDEX idx_impression_sources_date ON anchorImpressionsSources(account_id, date_start, date_end);
+
+-- Record the migration
+INSERT INTO migrations (migration_id, migration_name) VALUES (12, 'anchor impressions');

--- a/db_schema/schema.sql
+++ b/db_schema/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS migrations (
 -- -----------------------------------------
 -- IMPORTANT: this is the schema version
 -- ID has to be incremented for each change
-INSERT INTO migrations (migration_id, migration_name) VALUES (11, 'anchor episodesPage');
+INSERT INTO migrations (migration_id, migration_name) VALUES (12, 'anchor impressions');
 -- -----------------------------------------
 
 CREATE TABLE IF NOT EXISTS events (

--- a/fixtures/anchorImpressions.json
+++ b/fixtures/anchorImpressions.json
@@ -1,0 +1,202 @@
+{
+    "provider": "anchor",
+    "version": 1,
+    "retrieved": "2023-05-05T16:20:56.696026",
+    "meta": {
+        "show": "123abcde",
+        "endpoint": "impressions"
+    },
+    "range": {
+        "start": "2023-05-01",
+        "end": "2023-05-04"
+    },
+    "data": {
+        "impressionsFunnel": {
+            "data": {
+                "value": {
+                    "counts": [
+                        {
+                            "id": "impressions",
+                            "count": 4571
+                        },
+                        {
+                            "id": "considerations",
+                            "count": 731,
+                            "conversionPercent": 0.15992
+                        },
+                        {
+                            "id": "streams",
+                            "count": 381,
+                            "conversionPercent": 0.5212
+                        }
+                    ]
+                },
+                "isDistributedToSpotify": true
+            },
+            "error": null
+        },
+        "impressions": {
+            "data": {
+                "value": 30868,
+                "isDistributedToSpotify": true
+            },
+            "error": null
+        },
+        "dailyImpressions": {
+            "data": {
+                "value": [
+                    {
+                        "date": 1732233600,
+                        "value": 1145
+                    },
+                    {
+                        "date": 1732320000,
+                        "value": 860
+                    },
+                    {
+                        "date": 1732406400,
+                        "value": 846
+                    },
+                    {
+                        "date": 1732492800,
+                        "value": 952
+                    },
+                    {
+                        "date": 1732579200,
+                        "value": 1054
+                    },
+                    {
+                        "date": 1732665600,
+                        "value": 1079
+                    },
+                    {
+                        "date": 1732752000,
+                        "value": 915
+                    },
+                    {
+                        "date": 1732838400,
+                        "value": 1047
+                    },
+                    {
+                        "date": 1732924800,
+                        "value": 974
+                    },
+                    {
+                        "date": 1733011200,
+                        "value": 1050
+                    },
+                    {
+                        "date": 1733097600,
+                        "value": 849
+                    },
+                    {
+                        "date": 1733184000,
+                        "value": 873
+                    },
+                    {
+                        "date": 1733270400,
+                        "value": 1449
+                    },
+                    {
+                        "date": 1733356800,
+                        "value": 983
+                    },
+                    {
+                        "date": 1733443200,
+                        "value": 1036
+                    },
+                    {
+                        "date": 1733529600,
+                        "value": 857
+                    },
+                    {
+                        "date": 1733616000,
+                        "value": 955
+                    },
+                    {
+                        "date": 1733702400,
+                        "value": 1115
+                    },
+                    {
+                        "date": 1733788800,
+                        "value": 1261
+                    },
+                    {
+                        "date": 1733875200,
+                        "value": 1100
+                    },
+                    {
+                        "date": 1733961600,
+                        "value": 979
+                    },
+                    {
+                        "date": 1734048000,
+                        "value": 1381
+                    },
+                    {
+                        "date": 1734134400,
+                        "value": 882
+                    },
+                    {
+                        "date": 1734220800,
+                        "value": 1335
+                    },
+                    {
+                        "date": 1734307200,
+                        "value": 956
+                    },
+                    {
+                        "date": 1734393600,
+                        "value": 1146
+                    },
+                    {
+                        "date": 1734480000,
+                        "value": 967
+                    },
+                    {
+                        "date": 1734566400,
+                        "value": 932
+                    },
+                    {
+                        "date": 1734652800,
+                        "value": 1000
+                    },
+                    {
+                        "date": 1734739200,
+                        "value": 890
+                    }
+                ],
+                "isDistributedToSpotify": true
+            },
+            "error": null
+        },
+        "impressionsBySource": {
+            "data": {
+                "value": [
+                    {
+                        "id": "home",
+                        "value": 9082,
+                        "displayName": "Spotify Home"
+                    },
+                    {
+                        "id": "search",
+                        "value": 20849,
+                        "displayName": "Spotify Search"
+                    },
+                    {
+                        "id": "library",
+                        "value": 936,
+                        "displayName": "Spotify Library"
+                    },
+                    {
+                        "id": "other",
+                        "value": 1,
+                        "displayName": "Other Spotify features"
+                    }
+                ],
+                "isDistributedToSpotify": true
+            },
+            "error": null
+        }
+    }
+}

--- a/src/api/connectors/AnchorConnector.ts
+++ b/src/api/connectors/AnchorConnector.ts
@@ -17,6 +17,7 @@ import podcastEpisodeSchema from '../../schema/anchor/podcastEpisode.json'
 import totalPlaysSchema from '../../schema/anchor/totalPlays.json'
 import totalPlaysByEpisodeSchema from '../../schema/anchor/totalPlaysByEpisode.json'
 import uniqueListenersSchema from '../../schema/anchor/uniqueListeners.json'
+import impressionsSchema from '../../schema/anchor/impressions.json'
 
 import { ConnectorPayload } from '../../types/connector'
 import {
@@ -37,6 +38,7 @@ import {
     RawAnchorTotalPlaysByEpisodeData,
     RawAnchorUniqueListenersData,
     RawAnchorEpisodesPageData,
+    RawAnchorImpressionData,
 } from '../../types/provider/anchor'
 import { AnchorRepository } from '../../db/AnchorRepository'
 import { isArray } from 'mathjs'
@@ -253,6 +255,14 @@ class AnchorConnector implements ConnectorHandler {
             await this.repo.storeUniqueListeners(
                 accountId,
                 payload.data.data as RawAnchorUniqueListenersData
+            )
+        } else if (endpoint == 'impressions') {
+            validateJsonApiPayload(impressionsSchema, rawPayload)
+            await this.repo.storeImpressions(
+                accountId,
+                rawPayload.range.start,
+                rawPayload.range.end,
+                payload.data as RawAnchorImpressionData
             )
         } else {
             throw new PayloadError(

--- a/src/db/DBInitializer.ts
+++ b/src/db/DBInitializer.ts
@@ -133,6 +133,9 @@ class DBInitializer {
         }
         const migrationIdGoal = this.getMigrationGoal()
 
+        console.log('Latest migration id:', latestMigrationId)
+        console.log('Migration id goal:', migrationIdGoal)
+
         if (latestMigrationId >= migrationIdGoal) {
             return
         }

--- a/src/schema/anchor/impressions.json
+++ b/src/schema/anchor/impressions.json
@@ -1,0 +1,225 @@
+{
+    "$id": "http://openpodcast.dev/schema/anchor/impressions.schema.json",
+    "title": "Anchor / Spotify for Creators - Impressions data",
+    "type": "object",
+    "properties": {
+        "provider": {
+            "type": "string"
+        },
+        "version": {
+            "type": "number"
+        },
+        "retrieved": {
+            "type": "string"
+        },
+        "meta": {
+            "type": "object",
+            "properties": {
+                "show": {
+                    "type": "string"
+                },
+                "endpoint": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "show",
+                "endpoint"
+            ]
+        },
+        "range": {
+            "type": "object",
+            "properties": {
+                "start": {
+                    "type": "string"
+                },
+                "end": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "start",
+                "end"
+            ]
+        },
+        "data": {
+            "type": "object",
+            "properties": {
+                "impressionsFunnel": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "object",
+                                    "properties": {
+                                        "counts": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "count": {
+                                                        "type": "number"
+                                                    },
+                                                    "conversionPercent": {
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "id",
+                                                    "count"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "counts"
+                                    ]
+                                },
+                                "isDistributedToSpotify": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": [
+                                "value",
+                                "isDistributedToSpotify"
+                            ]
+                        },
+                        "error": {}
+                    },
+                    "required": [
+                        "data",
+                        "error"
+                    ]
+                },
+                "impressions": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "number"
+                                },
+                                "isDistributedToSpotify": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": [
+                                "value",
+                                "isDistributedToSpotify"
+                            ]
+                        },
+                        "error": {}
+                    },
+                    "required": [
+                        "data",
+                        "error"
+                    ]
+                },
+                "dailyImpressions": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "date": {
+                                                "type": "number"
+                                            },
+                                            "value": {
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": [
+                                            "date",
+                                            "value"
+                                        ]
+                                    }
+                                },
+                                "isDistributedToSpotify": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": [
+                                "value",
+                                "isDistributedToSpotify"
+                            ]
+                        },
+                        "error": {}
+                    },
+                    "required": [
+                        "data",
+                        "error"
+                    ]
+                },
+                "impressionsBySource": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "number"
+                                            },
+                                            "displayName": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "id",
+                                            "value",
+                                            "displayName"
+                                        ]
+                                    }
+                                },
+                                "isDistributedToSpotify": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": [
+                                "value",
+                                "isDistributedToSpotify"
+                            ]
+                        },
+                        "error": {}
+                    },
+                    "required": [
+                        "data",
+                        "error"
+                    ]
+                }
+            },
+            "required": [
+                "impressionsFunnel",
+                "impressions",
+                "dailyImpressions",
+                "impressionsBySource"
+            ]
+        }
+    },
+    "required": [
+        "provider",
+        "version",
+        "retrieved",
+        "meta",
+        "range",
+        "data"
+    ]
+}

--- a/src/types/provider/anchor.ts
+++ b/src/types/provider/anchor.ts
@@ -185,6 +185,50 @@ export interface RawAnchorUniqueListenersData {
     columnHeaders: [AnchorColumnHeader]
 }
 
+export interface RawAnchorImpressionData {
+    impressionsFunnel: {
+        data: {
+            value: {
+                counts: Array<{
+                    id: string
+                    count: number
+                    conversionPercent?: number
+                }>
+            }
+            isDistributedToSpotify: boolean
+        }
+        error: null | any
+    }
+    impressions: {
+        data: {
+            value: number
+            isDistributedToSpotify: boolean
+        }
+        error: null | any
+    }
+    dailyImpressions: {
+        data: {
+            value: Array<{
+                date: number
+                value: number
+            }>
+            isDistributedToSpotify: boolean
+        }
+        error: null | any
+    }
+    impressionsBySource: {
+        data: {
+            value: Array<{
+                id: string
+                value: number
+                displayName: string
+            }>
+            isDistributedToSpotify: boolean
+        }
+        error: null | any
+    }
+}
+
 export type AnchorDataPayload =
     | { kind: 'aggregatedPerformance'; data: AnchorAggregatedPerformanceData }
     | { kind: 'audienceSize'; data: RawAnchorAudienceSizeData }
@@ -203,6 +247,7 @@ export type AnchorDataPayload =
     | { kind: 'totalPlays'; data: RawAnchorTotalPlaysData }
     | { kind: 'totalPlaysByEpisode'; data: RawAnchorTotalPlaysByEpisodeData }
     | { kind: 'uniqueListeners'; data: RawAnchorUniqueListenersData }
+    | { kind: 'impressions'; data: RawAnchorImpressionData }
 
 export interface AnchorConnectorPayload {
     meta: {

--- a/tests/api_e2e/anchor.test.js
+++ b/tests/api_e2e/anchor.test.js
@@ -16,6 +16,7 @@ const anchorTotalPlaysPayload = require('../../fixtures/anchorTotalPlays.json')
 const anchorTotalPlaysByEpisodePayload = require('../../fixtures/anchorTotalPlaysByEpisode.json')
 const anchorUniqueListenersPayload = require('../../fixtures/anchorUniqueListeners.json')
 const anchorEpisodesPagePayload = require('../../fixtures/anchorEpisodesPage.json')
+const anchorImpressionsPayload = require('../../fixtures/anchorImpressions.json')
 
 const auth = require('./authheader')
 
@@ -226,6 +227,16 @@ describe('check Connector API with anchorUniqueListenersPayload', () => {
             .post('/connector')
             .set(auth)
             .send(anchorUniqueListenersPayload)
+        expect(response.statusCode).toBe(200)
+    })
+})
+
+describe('check Connector API with anchorImpressionsPayload', () => {
+    it('should return status 200 when sending proper Anchor payload', async () => {
+        const response = await request(baseURL)
+            .post('/connector')
+            .set(auth)
+            .send(anchorImpressionsPayload)
         expect(response.statusCode).toBe(200)
     })
 })


### PR DESCRIPTION
Introduce support for anchor impressions, including the necessary database schema changes and API integration to handle impression data.

See https://github.com/openpodcast/anchor-connector/pull/5