### PR TITLE
Add reportPodcastMetadata query as fallback for podcasts without custom report template

### DIFF
--- a/db_schema/queries/v1/reportPodcastMetadata.sql
+++ b/db_schema/queries/v1/reportPodcastMetadata.sql
@@ -1,0 +1,5 @@
+-- This query is called as a fallback in case we don't have any custom template for a podcast
+-- In this case, we use the default template and have to query the podcast metadata from the database
+SELECT pod_name
+FROM podcasts 
+WHERE account_id = @podcast_id


### PR DESCRIPTION
Couldn't generate a full report yet, because I forgot how to update the local DB with dummy data. The report is currently failing because there is no data for `reportApplePodcastBaseMetrics` for the default time range.