### PR TITLE
Generic Hoster Support New

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "cSpell.words": [
+    "Hoster",
+    "subdimension"
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ e2e-tests: ## Start end2end tests
 	@docker compose down
 
 	@echo "Done - Some important information for debugging:"
-	@echo "  - If the tests fail, consider to refresh the db by running 'make down' first"
+	@echo "  - If the tests fail, consider to refresh the db by running 'make down-db' first"
 	@echo "  - To have data for spotify, apple, and anchor, use podcast_id 3 for the tests"
 
 .PHONY: status

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,6 @@ build: ## Build the js code
 
 .PHONY: dev
 dev: ## Starts the api development server
-	echo "Do not forget to run 'make db-init-auth' to initialize the auth db"
-	echo "The main migration has to be finished before running the db-init-auth"
 	set -a && source env.local.test && set +a && npm run dev
 
 .PHONY: clean
@@ -113,15 +111,4 @@ send-api-req-prod: ## Send request to production
 db-shell: ## Opens the mysql shell inside the db container
 	docker compose exec db bash -c 'mysql -uopenpodcast -popenpodcast openpodcast'
 
-.PHONY: db-init-auth
-db-init-auth: ## Initialize the auth db after api is up
-	# creates the auth schema
-	docker cp ./db_schema/auth.sql $$(docker compose ps -q db):/tmp/auth.sql
-	docker compose exec db bash -c 'mysql -uopenpodcast -popenpodcast openpodcast_auth < /tmp/auth.sql'
-	
-	# creates some dummy auth data 
-	docker cp ./db_auth_data.sql $$(docker compose ps -q db):/tmp/auth_data.sql
-	docker compose exec db bash -c 'mysql -uopenpodcast -popenpodcast openpodcast_auth < /tmp/auth_data.sql'
-	docker cp ./db_auth_data.sql api-db-1:/tmp/auth_data.sql
-	docker compose exec db bash -c 'mysql -uopenpodcast -popenpodcast openpodcast_auth < /tmp/auth_data.sql'
 

--- a/Makefile
+++ b/Makefile
@@ -111,4 +111,7 @@ send-api-req-prod: ## Send request to production
 db-shell: ## Opens the mysql shell inside the db container
 	docker compose exec db bash -c 'mysql -uopenpodcast -popenpodcast openpodcast'
 
-
+.PHONY: test-one-e2e-%
+test-one-e2e-%: ## Run end2end tests for a specific test case
+	@echo "Running end2end test for: $*"
+	npx jest ./tests/api_e2e --verbose true --testNamePattern="$*"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ To query it, use the following endpoint: `/status`
 
 ## Development
 
+### Testing
+
+Run all tests:
+```bash
+make test               # Unit tests
+make e2e-tests          # End-to-end tests incl setup of stack
+```
+
+Run a specific test by name, dev and db server must be running:
+```bash
+make test-one-e2e-"test name here"
+```
+
+For example, to run only the authentication test:
+```bash
+make test-one-e2e-"should return not be authenticated with random token"
+```
+
 ### DB
 
 - `make up-db` starts the db and inits basic auth related tables

--- a/db_schema/dev_env/db_auth_data.sql
+++ b/db_schema/dev_env/db_auth_data.sql
@@ -1,3 +1,2 @@
-REPLACE INTO openpodcast.podcasts (account_id, pod_name) VALUES (3, 'test');
 -- Plaintext value of key_hash: dummy-cn389ncoiwuencr
 REPLACE INTO openpodcast_auth.apiKeys (key_hash, account_id) VALUES ('e158a7d3efa31fa234b6bdb1014b028491c515eb41abd8bd1c484ec6bd64f091', 3);

--- a/db_schema/dev_env/db_auth_init.sql
+++ b/db_schema/dev_env/db_auth_init.sql
@@ -7,5 +7,4 @@
 CREATE DATABASE IF NOT EXISTS openpodcast_auth;
 GRANT ALL PRIVILEGES ON openpodcast_auth.* TO 'openpodcast'@'%';
 
--- the auth schema itself is created by `make db-init-auth`
--- and should be run by a root user after the api has created the schema using the migrations
+-- the auth schema itself is created in the docker compose sourcing the manual_auth.sql file

--- a/db_schema/manual_auth.sql
+++ b/db_schema/manual_auth.sql
@@ -6,23 +6,21 @@
 -- auth database and write access to the main database
 
 -- define access keys for podcast sources
-CREATE TABLE IF NOT EXISTS podcastSources (
+CREATE TABLE IF NOT EXISTS openpodcast_auth.podcastSources (
   account_id INTEGER NOT NULL,
   source_name ENUM('spotify','apple','anchor','podigee'),
   source_podcast_id VARCHAR(64) NOT NULL,
   -- keys are stored in json format and are encrypted by the client
   source_access_keys_encrypted JSON NOT NULL,
   source_access_keys_created TIMESTAMP NULL DEFAULT NULL,
-  PRIMARY KEY (account_id, source_name),
-  CONSTRAINT podcastSources_account_id_fk FOREIGN KEY (account_id) REFERENCES openpodcast.podcasts(account_id) ON DELETE CASCADE
+  PRIMARY KEY (account_id, source_name)
 );
 
-CREATE TABLE IF NOT EXISTS apiKeys (
+CREATE TABLE IF NOT EXISTS openpodcast_auth.apiKeys (
   -- SHA256 hash of the key, no salting as we are storing long random keys
   -- and the hash is used to lookup the key which would be more complicated using salting
   -- and wouldn't increase security a lot
   key_hash CHAR(64) NOT NULL,
   account_id INTEGER NOT NULL,
-  PRIMARY KEY (key_hash, account_id),
-  CONSTRAINT apiKeys_account_id_fk FOREIGN KEY (account_id) REFERENCES openpodcast.podcasts(account_id) ON DELETE CASCADE
+  PRIMARY KEY (key_hash, account_id)
 );

--- a/db_schema/migrations/14_generic_hoster.sql
+++ b/db_schema/migrations/14_generic_hoster.sql
@@ -11,7 +11,8 @@ CREATE TABLE IF NOT EXISTS hosterPodcastMetadata (
 CREATE TABLE IF NOT EXISTS subdimensions (
     dim_id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
     dim_name CHAR(64) NOT NULL,
-    PRIMARY KEY (dim_id)
+    PRIMARY KEY (dim_id),
+    UNIQUE KEY (dim_name)
 );
 
 CREATE TABLE IF NOT EXISTS hosterPodcastMetrics (

--- a/db_schema/migrations/14_generic_hoster.sql
+++ b/db_schema/migrations/14_generic_hoster.sql
@@ -1,0 +1,67 @@
+CREATE TABLE IF NOT EXISTS hosterPodcastMetadata (
+  account_id INTEGER NOT NULL,
+  hoster_id SMALLINT UNSIGNED NOT NULL,
+  date DATE DEFAULT (CURRENT_DATE),
+  name VARCHAR(2048) NOT NULL,
+  -- Date is not part of the primary key
+  -- because we only want to store the latest data
+  PRIMARY KEY (account_id, hoster_id)
+);
+
+CREATE TABLE IF NOT EXISTS subdimensions (
+    dim_id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    dim_name CHAR(64) NOT NULL,
+    PRIMARY KEY (dim_id)
+);
+
+CREATE TABLE IF NOT EXISTS hosterPodcastMetrics (
+  account_id INTEGER NOT NULL,
+  hoster_id SMALLINT UNSIGNED NOT NULL,
+  start DATETIME NOT NULL,
+  end DATETIME NOT NULL,
+  dimension ENUM(
+    'downloads',
+    'platforms',
+    'clients',
+    'sources'
+  ) NOT NULL,
+  subdimension SMALLINT UNSIGNED NOT NULL,
+  value INTEGER NOT NULL,
+  PRIMARY KEY (account_id, hoster_id, start, end, dimension, subdimension),
+  CONSTRAINT fk_subdimension_podcast
+    FOREIGN KEY (subdimension) REFERENCES subdimensions(dim_id)
+    ON DELETE RESTRICT
+);
+
+CREATE TABLE IF NOT EXISTS hosterEpisodeMetadata (
+  account_id INTEGER NOT NULL,
+  hoster_id SMALLINT UNSIGNED NOT NULL,
+  episode_id VARCHAR(128) NOT NULL,
+  ep_name VARCHAR(2048) NOT NULL,
+  ep_url VARCHAR(2048),
+  -- Date could be NULL for unpublished episodes
+  ep_release_date DATETIME,
+  PRIMARY KEY (account_id, hoster_id, episode_id)
+);
+
+CREATE TABLE IF NOT EXISTS hosterEpisodeMetrics (
+  account_id INTEGER NOT NULL,
+  hoster_id SMALLINT UNSIGNED NOT NULL,
+  episode_id VARCHAR(128) NOT NULL,
+  start DATETIME NOT NULL,
+  end DATETIME NOT NULL,
+  dimension ENUM(
+    'downloads',
+    'platforms',
+    'clients',
+    'sources'
+  ) NOT NULL,
+  subdimension SMALLINT UNSIGNED NOT NULL,
+  value INTEGER NOT NULL,
+  PRIMARY KEY (account_id, hoster_id, episode_id, start, end, dimension, subdimension),
+    CONSTRAINT fk_subdimension_episode
+        FOREIGN KEY (subdimension) REFERENCES subdimensions(dim_id)
+        ON DELETE RESTRICT
+);
+
+INSERT INTO migrations (migration_id, migration_name) VALUES (14, 'genericHoster');

--- a/db_schema/queries/v1/reportAnchorAvgEpisodeLTRHistogram.sql
+++ b/db_schema/queries/v1/reportAnchorAvgEpisodeLTRHistogram.sql
@@ -1,19 +1,23 @@
-WITH
-latestValidDate as ( SELECT MAX(date) as d FROM anchorEpisodePerformance WHERE account_id = @podcast_id),  
-baseData as (SELECT * FROM anchorEpisodePerformance WHERE date = (SELECT d FROM latestValidDate) AND account_id = @podcast_id)
-
+WITH latestValidDate as ( SELECT MAX(date) FROM anchorEpisodePerformance WHERE account_id = @podcast_id)  
 SELECT
 	account_id,
 	sec,
 	round(avg(JSON_EXTRACT(samples, concat('$."', sec, '"')) / max_listeners) * 100, 2) as average_listener_percent
 FROM
-	baseData
+	anchorEpisodePerformance
 CROSS JOIN
 	 json_table(
 	        json_keys(samples)
 	        ,
 	'$[*]' columns(sec int path '$')
 	    ) samples
+WHERE
+	date = (
+	SELECT
+		date
+	FROM
+		latestValidDate)
+	and account_id = @podcast_id
 GROUP BY
 	account_id,
 	sec

--- a/db_schema/queries/v1/reportAnchorAvgEpisodeLTRHistogram.sql
+++ b/db_schema/queries/v1/reportAnchorAvgEpisodeLTRHistogram.sql
@@ -1,26 +1,22 @@
-WITH latestValidDate as ( SELECT MAX(date) FROM anchorEpisodePerformance WHERE account_id = @podcast_id)  
+WITH
+latestValidDate as ( SELECT MAX(date) as d FROM anchorEpisodePerformance WHERE account_id = @podcast_id),  
+baseData as (SELECT * FROM anchorEpisodePerformance WHERE	date = (SELECT d	FROM latestValidDate) AND account_id = @podcast_id)
+
 SELECT
 	account_id,
 	sec,
 	round(avg(JSON_EXTRACT(samples, concat('$."', sec, '"')) / max_listeners) * 100, 2) as average_listener_percent
 FROM
-	anchorEpisodePerformance
+	baseData
 CROSS JOIN
 	 json_table(
 	        json_keys(samples)
 	        ,
 	'$[*]' columns(sec int path '$')
 	    ) samples
-WHERE
-	date = (
-	SELECT
-		date
-	FROM
-		latestValidDate)
-	and account_id = @podcast_id
 GROUP BY
 	account_id,
 	sec
 	-- cut off tail of the average values, for which we don't have at least 3 episodes
 HAVING
-	count(*) > 2
+	count(*) > 2 

--- a/db_schema/schema.sql
+++ b/db_schema/schema.sql
@@ -696,5 +696,60 @@ CREATE TABLE IF NOT EXISTS anchorUniqueListeners (
     PRIMARY KEY (account_id, date)
 );
 
+-- Support for generic hosters, e.g. Podigee (migration 12)
 
+CREATE TABLE IF NOT EXISTS hosterPodcastMetadata (
+  account_id INTEGER NOT NULL,
+  hoster_id MEDIUMINT UNSIGNED NOT NULL,
+  date DATE NOT NULL,
+  name VARCHAR(2048) NOT NULL,
+  -- Date is not part of the primary key
+  -- because we only want to store the latest data
+  PRIMARY KEY (account_id, hoster_id)
+);
+
+CREATE TABLE IF NOT EXISTS hosterPodcastMetrics (
+  account_id INTEGER NOT NULL,
+  hoster_id MEDIUMINT UNSIGNED NOT NULL,
+  start DATETIME NOT NULL,
+  end DATETIME NOT NULL,
+  dimension ENUM(
+    'downloads',
+    'platforms',
+    'clients',
+    'sources'
+  ) NOT NULL,
+  subdimension VARCHAR(255) DEFAULT '' NOT NULL,
+  value INTEGER NOT NULL,
+  PRIMARY KEY (account_id, hoster_id, start, end, dimension, subdimension)
+);
+
+
+CREATE TABLE IF NOT EXISTS hosterEpisodeMetadata (
+  account_id INTEGER NOT NULL,
+  hoster_id MEDIUMINT UNSIGNED NOT NULL,
+  episode_id VARCHAR(128) NOT NULL,
+  ep_name VARCHAR(2048) NOT NULL,
+  ep_url VARCHAR(2048),
+  -- Date could be NULL for unpublished episodes
+  ep_release_date DATETIME,
+  PRIMARY KEY (account_id, hoster_id, episode_id)
+);
+
+CREATE TABLE IF NOT EXISTS hosterEpisodeMetrics (
+  account_id INTEGER NOT NULL,
+  hoster_id MEDIUMINT UNSIGNED NOT NULL,
+  episode_id VARCHAR(128) NOT NULL,
+  start DATETIME NOT NULL,
+  end DATETIME NOT NULL,
+  dimension ENUM(
+    'downloads',
+    'platforms',
+    'clients',
+    'sources'
+  ) NOT NULL,
+  subdimension VARCHAR(255) DEFAULT '' NOT NULL,
+  value INTEGER NOT NULL,
+  PRIMARY KEY (account_id, hoster_id, episode_id, start, end, dimension, subdimension)
+);
 

--- a/db_schema/schema.sql
+++ b/db_schema/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS migrations (
 -- -----------------------------------------
 -- IMPORTANT: this is the schema version
 -- ID has to be incremented for each change
-INSERT INTO migrations (migration_id, migration_name) VALUES (13, 'increase ep_guid size');
+INSERT INTO migrations (migration_id, migration_name) VALUES (14, 'genericHoster');
 -- -----------------------------------------
 
 CREATE TABLE IF NOT EXISTS events (
@@ -696,21 +696,27 @@ CREATE TABLE IF NOT EXISTS anchorUniqueListeners (
     PRIMARY KEY (account_id, date)
 );
 
--- Support for generic hosters, e.g. Podigee (migration 12)
+-- Generic Host Suppport, introduced with migration 14
 
 CREATE TABLE IF NOT EXISTS hosterPodcastMetadata (
   account_id INTEGER NOT NULL,
-  hoster_id MEDIUMINT UNSIGNED NOT NULL,
-  date DATE NOT NULL,
+  hoster_id SMALLINT UNSIGNED NOT NULL,
+  date DATE DEFAULT (CURRENT_DATE),
   name VARCHAR(2048) NOT NULL,
   -- Date is not part of the primary key
   -- because we only want to store the latest data
   PRIMARY KEY (account_id, hoster_id)
 );
 
+CREATE TABLE IF NOT EXISTS subdimensions (
+    dim_id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    dim_name CHAR(64) NOT NULL,
+    PRIMARY KEY (dim_id)
+);
+
 CREATE TABLE IF NOT EXISTS hosterPodcastMetrics (
   account_id INTEGER NOT NULL,
-  hoster_id MEDIUMINT UNSIGNED NOT NULL,
+  hoster_id SMALLINT UNSIGNED NOT NULL,
   start DATETIME NOT NULL,
   end DATETIME NOT NULL,
   dimension ENUM(
@@ -719,15 +725,17 @@ CREATE TABLE IF NOT EXISTS hosterPodcastMetrics (
     'clients',
     'sources'
   ) NOT NULL,
-  subdimension VARCHAR(255) DEFAULT '' NOT NULL,
+  subdimension SMALLINT UNSIGNED NOT NULL,
   value INTEGER NOT NULL,
-  PRIMARY KEY (account_id, hoster_id, start, end, dimension, subdimension)
+  PRIMARY KEY (account_id, hoster_id, start, end, dimension, subdimension),
+  CONSTRAINT fk_subdimension_podcast
+    FOREIGN KEY (subdimension) REFERENCES subdimensions(dim_id)
+    ON DELETE RESTRICT
 );
-
 
 CREATE TABLE IF NOT EXISTS hosterEpisodeMetadata (
   account_id INTEGER NOT NULL,
-  hoster_id MEDIUMINT UNSIGNED NOT NULL,
+  hoster_id SMALLINT UNSIGNED NOT NULL,
   episode_id VARCHAR(128) NOT NULL,
   ep_name VARCHAR(2048) NOT NULL,
   ep_url VARCHAR(2048),
@@ -738,7 +746,7 @@ CREATE TABLE IF NOT EXISTS hosterEpisodeMetadata (
 
 CREATE TABLE IF NOT EXISTS hosterEpisodeMetrics (
   account_id INTEGER NOT NULL,
-  hoster_id MEDIUMINT UNSIGNED NOT NULL,
+  hoster_id SMALLINT UNSIGNED NOT NULL,
   episode_id VARCHAR(128) NOT NULL,
   start DATETIME NOT NULL,
   end DATETIME NOT NULL,
@@ -748,8 +756,10 @@ CREATE TABLE IF NOT EXISTS hosterEpisodeMetrics (
     'clients',
     'sources'
   ) NOT NULL,
-  subdimension VARCHAR(255) DEFAULT '' NOT NULL,
+  subdimension SMALLINT UNSIGNED NOT NULL,
   value INTEGER NOT NULL,
-  PRIMARY KEY (account_id, hoster_id, episode_id, start, end, dimension, subdimension)
+  PRIMARY KEY (account_id, hoster_id, episode_id, start, end, dimension, subdimension),
+    CONSTRAINT fk_subdimension_episode
+        FOREIGN KEY (subdimension) REFERENCES subdimensions(dim_id)
+        ON DELETE RESTRICT
 );
-

--- a/db_schema/schema.sql
+++ b/db_schema/schema.sql
@@ -711,7 +711,8 @@ CREATE TABLE IF NOT EXISTS hosterPodcastMetadata (
 CREATE TABLE IF NOT EXISTS subdimensions (
     dim_id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT,
     dim_name CHAR(64) NOT NULL,
-    PRIMARY KEY (dim_id)
+    PRIMARY KEY (dim_id),
+    UNIQUE KEY (dim_name)
 );
 
 CREATE TABLE IF NOT EXISTS hosterPodcastMetrics (

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,9 @@ services:
         volumes:
             - mysqldata:/var/lib/mysql
             - ./dbinit.sql:/docker-entrypoint-initdb.d/1_init.sql
-            - ./db_auth_init.sql:/docker-entrypoint-initdb.d/2_init_auth.sql
+            - ./db_schema/dev_env/db_auth_init.sql:/docker-entrypoint-initdb.d/3_dev_env_auth.sql
+            - ./db_schema/manual_auth.sql:/docker-entrypoint-initdb.d/4_manual_auth.sql
+            - ./db_schema/dev_env/db_auth_data.sql:/docker-entrypoint-initdb.d/5_dev_env_auth_data.sql
         ports:
             - '33006:3306'
         environment:

--- a/fixtures/hosterEpisodeMetadata.json
+++ b/fixtures/hosterEpisodeMetadata.json
@@ -1,0 +1,15 @@
+{
+    "provider": "podigee",
+    "version": 1,
+    "retrieved": "2022-10-04T10:09:46.463Z",
+    "meta": {
+        "endpoint": "metadata",
+        "show": "0tJRC0UsObPCWLmmzmOkIs",
+        "episode": "123XASDF"
+    },
+    "data": {
+        "ep_name": "Name of episode",
+        "ep_url": "https://www.example.com/episode/1243940",
+        "ep_release_date": "2022-10-04T10:09:46.463Z"
+    }
+}

--- a/fixtures/hosterEpisodeMetrics.json
+++ b/fixtures/hosterEpisodeMetrics.json
@@ -1,0 +1,28 @@
+{
+    "provider": "podigee",
+    "version": 1,
+    "retrieved": "2022-10-04T10:09:46.463Z",
+    "meta": {
+        "endpoint": "metrics",
+        "show": "0tJRC0UsObPCWLmmzmOkIs",
+        "episode": "123XASDF"
+    },
+    "data": {
+        "metrics": [
+            {
+                "start": "2022-10-20",
+                "end": "2022-10-21",
+                "dimension": "downloads",
+                "subdimension": "total",
+                "value": 100000
+            },
+            {
+                "start": "2022-10-20",
+                "end": "2022-10-21",
+                "dimension": "clients",
+                "subdimension": "PocketCasts",
+                "value": 5
+            }
+        ]
+    }
+}

--- a/fixtures/hosterPodcastMetadata.json
+++ b/fixtures/hosterPodcastMetadata.json
@@ -1,0 +1,12 @@
+{
+    "provider": "podigee",
+    "version": 1,
+    "retrieved": "2022-10-04T10:09:46.463Z",
+    "meta": {
+        "show": "0tJRC0UsObPCWLmmzmOkIs",
+        "endpoint": "metadata"
+    },
+    "data": {
+        "name": "TOPP - The Open Podcast Podcast"
+    }
+}

--- a/fixtures/hosterPodcastMetrics.json
+++ b/fixtures/hosterPodcastMetrics.json
@@ -1,0 +1,27 @@
+{
+    "provider": "podigee",
+    "version": 1,
+    "retrieved": "2022-10-04T10:09:46.463Z",
+    "meta": {
+        "endpoint": "metrics",
+        "show": "0tJRC0UsObPCWLmmzmOkIs"
+    },
+    "data": {
+        "metrics": [
+            {
+                "start": "2022-10-20",
+                "end": "2022-10-21",
+                "dimension": "clients",
+                "subdimension": "PocketCasts",
+                "value": 5
+            },
+            {
+                "start": "2022-10-20",
+                "end": "2022-10-21",
+                "dimension": "clients",
+                "subdimension": "PocketCasts",
+                "value": 5
+            }
+        ]
+    }
+}

--- a/fixtures/spotifyEpisodesMetadata.json
+++ b/fixtures/spotifyEpisodesMetadata.json
@@ -1,18 +1,16 @@
 {
-  "provider": "spotify",
-  "version": 1,
-  "retrieved": "2022-10-04T10:09:46.463Z",
-  "meta": {
-    "show": "0tJRC0UsObPCWLmmzmOkIs",
-    "endpoint": "episodes"
-  },
-  "range": {
-    "start": "2022-10-03",
-    "end": "2022-10-04"
-  },
-  "data": {
-    "episodes": [
-      {
+    "provider": "spotify",
+    "version": 1,
+    "retrieved": "2022-10-04T10:09:46.463Z",
+    "meta": {
+        "show": "0tJRC0UsObPCWLmmzmOkIs",
+        "endpoint": "episodeMetadata"
+    },
+    "range": {
+        "start": "2022-10-03",
+        "end": "2022-10-04"
+    },
+    "data": {
         "name": "#03 Vendor Lock-in of Big Podcast Hosters",
         "id": "2ebg5MhyOK9rotpCBfe830",
         "url": "https://open.spotify.com/episode/2ebg5MhyOK9rotpCBfe830",
@@ -27,55 +25,5 @@
         "listeners": 0,
         "sparkLine": [],
         "hasVideo": false
-      },
-      {
-        "name": "#02 Our Plan - Does Spotify cache podcasts?",
-        "id": "7Im0OmzL44oedpHpBNvA19",
-        "url": "https://open.spotify.com/episode/7Im0OmzL44oedpHpBNvA19",
-        "releaseDate": "2022-09-06",
-        "artworkUrl": "https://i.scdn.co/image/ab6765630000ba8a949a7b5c3456a4599488eb46",
-        "description": "How do podcasts work on a technical level and how do we want to avoid common pitfalls with podcast hosting?Fundamentally podcasts are very simple. Everyone can host one and publish content with open formats like RSS. The devil is in the details as they say. Many platforms like Spotify and Apple Music have their own logic for handling podcasts. We dive into the pitfalls of hosting podcasts and the advantages of open statistics data for hosts.We will also talk about our plans on how to set up Open Podcast. We plan to use an open proxy (a little program that transparently tracks listens and subscribers).Spotify caches requests to episodes, which means our proxy can not track these requests.Therefore we also plan to fetch existing data from Spotify, Apple, and Amazon directly with so-called importers.LinksRSS 2.0 specification: https://validator.w3.org/feed/docs/rss2.htmlHow Spotify caches requests (German): https://sendegate.de/t/spotify-und-die-hostingpartner/10387Transistor Spotify Passthrough: https://transistor.fm/changelog/spotify-passthrough/&nbsp;HostsMatthias Endler (https://twitter.com/matthiasendler)&nbsp;Wolfgang Gassler (https://twitter.com/schafele)FeedbackEmail: echo@openpodcast.dev&nbsp;Twitter: https://twitter.com/OpenPodcastDev&nbsp;CreditsThe theme music is &ldquo;Orbiting A Distant Planet'' by Quantum Jazz and is licensed under a Attribution-ShareAlike 3.0 International License.",
-        "explict": false,
-        "language": "en-US",
-        "duration": 815400,
-        "starts": 0,
-        "streams": 0,
-        "listeners": 0,
-        "sparkLine": [],
-        "hasVideo": false
-      },
-      {
-        "name": "#01 The Open Podcast Project",
-        "id": "48DAya24YOjS7Ez49JSH3y",
-        "url": "https://open.spotify.com/episode/48DAya24YOjS7Ez49JSH3y",
-        "releaseDate": "2022-08-30",
-        "artworkUrl": "https://i.scdn.co/image/ab6765630000ba8a0e7ce18958e22a9ce0dc0127",
-        "description": "Welcome to &ldquo;The Open Podcast Podcast&rdquo;, a weekly show about the Podcast Ecosystem and our attempt to build an open source analytics platform for podcast hosts.In this episode we introduce the Open Podcast project and explain why we think it&rsquo;s important to have open alternatives to existing podcast hosting platforms.We believe that the Podcast ecosystem needs to remain open. Contrary to what some proprietary platforms believe, we think people value choice and freedom.We want to counter fragmentation, paywalls, and limits.We believe that Podcast hosts can grow an audience without locking people in or being dependent on the big players.If anything we should work on expanding the RSS standard to support more functionality.Linkshttps://twitter.com/chrismessina/status/1384572264566255619Michael Migano from Anchor (which belongs to Spotify): &ldquo;Podcasting, RSS, Openness, and Choice&ldquo;. https://mignano.medium.com/podcasting-rss-openness-and-choice-50223b1f16d0Media Tech Lab Grant: https://www.media-lab.de/en/programs/media-tech-lab CopyrightThe theme music is &ldquo;Orbiting A Distant Planet'' by Quantum Jazz and is licensed under a Attribution-ShareAlike 3.0 International License.HostsMatthias Endler (https://twitter.com/matthiasendler)&nbsp;Wolfgang Gassler (https://twitter.com/schafele)FeedbackEmail: echo@openpodcast.dev&nbsp;Twitter: https://twitter.com/OpenPodcastDev&nbsp;",
-        "explict": false,
-        "language": "en-US",
-        "duration": 566055,
-        "starts": 0,
-        "streams": 0,
-        "listeners": 0,
-        "sparkLine": [],
-        "hasVideo": false
-      }
-    ],
-    "totalPages": 1,
-    "currentPage": 1,
-    "totalEpisodes": 3,
-    "metadata": {
-      "network": {
-        "id": "6BJtNPLQSTx541yBr7HDFq",
-        "name": "Spotify Direct Submission",
-        "doingBusinessAs": "Spotify Direct Submission"
-      },
-      "show": {
-        "id": "0WgG3O6LTgbGN5SQmVrNRG",
-        "name": "TOPP - The Open Podcast Podcast"
-      },
-      "startDate": "2022-09-15",
-      "endDate": "2022-09-16"
     }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsc",
-    "dev": "concurrently \"tsc --watch\" \"nodemon -e ts,tsx,sql,js -q dist/index.js \"",
+    "dev": "nodemon --exec ts-node src/index.ts --watch src --ext ts",
     "lint": "npx eslint --config .eslintrc.js  ./src"
   },
   "license": "MIT",

--- a/src/api/connectors/HosterConnector.ts
+++ b/src/api/connectors/HosterConnector.ts
@@ -1,0 +1,78 @@
+import { ConnectorHandler } from '.'
+import { validateJsonApiPayload } from '../JsonPayloadValidator'
+import { PayloadError } from '../../types/api'
+import { ConnectorPayload } from '../../types/connector'
+import { HosterRepository } from '../../db/HosterRepository'
+
+import hosterEpisodeMetadataSchema from '../../schema/hoster/hosterEpisodeMetadata.json'
+import hosterPodcastMetadataSchema from '../../schema/hoster/hosterPodcastMetadata.json'
+import hosterEpisodeMetricsSchema from '../../schema/hoster/hosterEpisodeMetrics.json'
+import hosterPodcastMetricsSchema from '../../schema/hoster/hosterPodcastMetrics.json'
+import {
+    HosterEpisodeMetadataPayload,
+    HosterPodcastMetadataPayload,
+    HosterMetricsPayload,
+} from '../../types/provider/hoster'
+
+class HosterConnector implements ConnectorHandler {
+    repo: HosterRepository
+    hosterId: number
+
+    constructor(repo: HosterRepository, hosterId: number) {
+        this.repo = repo
+        this.hosterId = hosterId
+    }
+
+    async handleRequest(
+        accountId: number,
+        payload: ConnectorPayload
+    ): Promise<void> | never {
+        if (payload.meta.endpoint === 'metadata') {
+            if (payload.meta.episode) {
+                validateJsonApiPayload(
+                    hosterEpisodeMetadataSchema,
+                    payload.data
+                )
+                return await this.repo.storeHosterEpisodeMetadata(
+                    this.hosterId,
+                    accountId,
+                    payload.meta.episode,
+                    payload.data as HosterEpisodeMetadataPayload
+                )
+            } else {
+                validateJsonApiPayload(
+                    hosterPodcastMetadataSchema,
+                    payload.data
+                )
+                return await this.repo.storeHosterPodcastMetadata(
+                    this.hosterId,
+                    accountId,
+                    payload.data as HosterPodcastMetadataPayload
+                )
+            }
+        } else if (payload.meta.endpoint === 'metrics') {
+            if (payload.meta.episode) {
+                validateJsonApiPayload(hosterEpisodeMetricsSchema, payload.data)
+                return await this.repo.storeHosterEpisodeMetrics(
+                    this.hosterId,
+                    accountId,
+                    payload.meta.episode,
+                    payload.data as HosterMetricsPayload
+                )
+            } else {
+                validateJsonApiPayload(hosterPodcastMetricsSchema, payload.data)
+                return await this.repo.storeHosterPodcastMetrics(
+                    this.hosterId,
+                    accountId,
+                    payload.data as HosterMetricsPayload
+                )
+            }
+        } else {
+            throw new PayloadError(
+                `Unknown endpoint in meta: ${payload.meta.endpoint}`
+            )
+        }
+    }
+}
+
+export { HosterConnector }

--- a/src/api/connectors/SpotifyConnector.ts
+++ b/src/api/connectors/SpotifyConnector.ts
@@ -106,19 +106,18 @@ class SpotifyConnector implements ConnectorHandler {
         } else if (payload.meta.endpoint === 'aggregate') {
             //validates the payload and throws an error if it is not valid
             validateJsonApiPayload(aggregateSchema, payload.data)
+            const data = payload.data as SpotifyEpisodeAggregatePayload
 
             if (payload.meta.episode !== undefined) {
                 return await this.repo.storeEpisodeAggregate(
                     accountId,
                     payload.meta.episode,
-                    payload.range.start,
-                    payload.data as SpotifyEpisodeAggregatePayload
+                    data
                 )
             } else {
                 return await this.repo.storePodcastAggregate(
                     accountId,
-                    payload.range.start,
-                    payload.data as SpotifyPodcastAggregatePayload
+                    data as SpotifyPodcastAggregatePayload
                 )
             }
         } else {

--- a/src/db/AccountKeyRepository.ts
+++ b/src/db/AccountKeyRepository.ts
@@ -26,7 +26,11 @@ class AccountKeyRepository {
             [hashedKey]
         )
 
-        return (rows[0].account_id as number) || null
+        if (!Array.isArray(rows) || rows.length !== 1 || !rows[0].account_id) {
+            return null // No account found for this key
+        }
+
+        return rows[0].account_id as number
     }
 
     /**

--- a/src/db/HosterRepository.ts
+++ b/src/db/HosterRepository.ts
@@ -110,9 +110,7 @@ class HosterRepository {
                 convertAnyDatetimeToDBString(metric.start),
                 convertAnyDatetimeToDBString(metric.end),
                 metric.dimension,
-                metric.subdimension
-                    ? await this.getSubDimensionId(metric.subdimension)
-                    : null,
+                await this.getSubDimensionId(metric.subdimension),
                 metric.value
             )
         }
@@ -149,9 +147,7 @@ class HosterRepository {
                 convertAnyDatetimeToDBString(metric.start),
                 convertAnyDatetimeToDBString(metric.end),
                 metric.dimension,
-                metric.subdimension
-                    ? await this.getSubDimensionId(metric.subdimension)
-                    : null,
+                await this.getSubDimensionId(metric.subdimension),
                 metric.value
             )
         }

--- a/src/db/HosterRepository.ts
+++ b/src/db/HosterRepository.ts
@@ -1,0 +1,152 @@
+import {
+    HosterEpisodeMetadataPayload,
+    HosterMetricsPayload,
+    HosterPodcastMetadataPayload,
+} from '../types/provider/hoster'
+
+const convertAnyDatetimeToDBString = (date: any): string => {
+    const dateObj = new Date(date)
+    return dateObj.toISOString().slice(0, 19).replace('T', ' ')
+}
+
+class HosterRepository {
+    pool
+
+    constructor(pool: any) {
+        this.pool = pool
+    }
+
+    getTodayDBString(): string {
+        const today = new Date()
+
+        // format to YYYY-mm-dd
+        // Note that today.toLocaleDateString('en-CA') returned `DD/MM/YYYY` on
+        // some systems
+        return (
+            today.getFullYear() +
+            '-' +
+            (today.getMonth() + 1) +
+            '-' +
+            today.getDate()
+        )
+    }
+
+    async storeHosterPodcastMetadata(
+        hosterId: number,
+        accountId: number,
+        data: HosterPodcastMetadataPayload
+    ): Promise<any> {
+        const replaceStmt = `REPLACE INTO hosterPodcastMetadata (
+            account_id,
+            date,
+            hoster_id,
+            name
+            ) VALUES
+            (?,?,?,?)`
+
+        return await this.pool.query(replaceStmt, [
+            accountId,
+            this.getTodayDBString(),
+            hosterId,
+            data.name,
+        ])
+    }
+
+    async storeHosterEpisodeMetadata(
+        hosterId: number,
+        accountId: number,
+        episode: string,
+        data: HosterEpisodeMetadataPayload
+    ): Promise<any> {
+        const replaceStmt = `REPLACE INTO hosterEpisodeMetadata (
+            account_id,
+            hoster_id,
+            episode_id,
+            ep_name,
+            ep_url,
+            ep_release_date
+            ) VALUES
+            (?,?,?,?,?,?)`
+        return await this.pool.query(replaceStmt, [
+            accountId,
+            hosterId,
+            episode,
+            data.ep_name,
+            data.ep_url,
+            convertAnyDatetimeToDBString(data.ep_release_date),
+        ])
+    }
+
+    async storeHosterEpisodeMetrics(
+        hosterId: number,
+        accountId: number,
+        episode: string,
+        data: HosterMetricsPayload
+    ): Promise<any> {
+        if (!data.metrics) {
+            // No metrics to store
+            return
+        }
+
+        const replaceStmt =
+            `REPLACE INTO hosterEpisodeMetrics (
+            account_id,
+            hoster_id,
+            episode_id,
+            start,
+            end,
+            dimension,
+            subdimension,
+            value
+        ) VALUES ` + data.metrics.map(() => '(?,?,?,?,?,?,?,?)').join(',')
+
+        const values = data.metrics.flatMap((metric) => [
+            accountId,
+            hosterId,
+            episode,
+            convertAnyDatetimeToDBString(metric.start),
+            convertAnyDatetimeToDBString(metric.end),
+            metric.dimension,
+            metric.subdimension,
+            metric.value,
+        ])
+
+        return this.pool.query(replaceStmt, values)
+    }
+
+    async storeHosterPodcastMetrics(
+        hosterId: number,
+        accountId: number,
+        data: HosterMetricsPayload
+    ): Promise<any> {
+        if (!data.metrics) {
+            // No metrics to store
+            return
+        }
+
+        const replaceStmt =
+            `REPLACE INTO hosterPodcastMetrics (
+            account_id,
+            hoster_id,
+            start,
+            end,
+            dimension,
+            subdimension,
+            value
+        ) VALUES ` + data.metrics.map(() => '(?,?,?,?,?,?,?)').join(',')
+
+        const values = data.metrics.flatMap((metric) => [
+            accountId,
+            hosterId,
+            convertAnyDatetimeToDBString(metric.start),
+            convertAnyDatetimeToDBString(metric.end),
+            metric.dimension,
+            metric.subdimension,
+            metric.value,
+        ])
+
+        return this.pool.query(replaceStmt, values)
+    }
+}
+
+export { HosterRepository }

--- a/src/db/HosterRepository.ts
+++ b/src/db/HosterRepository.ts
@@ -157,6 +157,8 @@ class HosterRepository {
     }
 
     async getSubDimensionId(dimension: string): Promise<number> {
+        // to reduce errors we consider always lower case
+        dimension = dimension.toLowerCase()
         const id = this.subDimensionIdCache.get(dimension)
 
         if (id !== undefined) {
@@ -165,7 +167,7 @@ class HosterRepository {
 
         // Insert or ignore if exists, then get the ID
         await this.pool.execute(
-            'INSERT INTO subdimensions (dim_name) VALUES (?)',
+            'INSERT IGNORE INTO subdimensions (dim_name) VALUES (?)',
             [dimension]
         )
 

--- a/src/db/SpotifyRepository.ts
+++ b/src/db/SpotifyRepository.ts
@@ -278,7 +278,6 @@ class SpotifyRepository {
     async storeEpisodeAggregate(
         accountId: number,
         episodeId: string,
-        date: string,
         payload: SpotifyEpisodeAggregatePayload
     ): Promise<any> {
         const replaceStmt = `REPLACE INTO spotifyEpisodeAggregate (account_id, episode_id, spa_date, spa_facet, spa_facet_type, 
@@ -292,7 +291,7 @@ class SpotifyRepository {
                     return await this.pool.execute(replaceStmt, [
                         accountId,
                         episodeId,
-                        date,
+                        payload.start,
                         ageGroup,
                         'age',
                         entry.counts.NOT_SPECIFIED,
@@ -305,7 +304,7 @@ class SpotifyRepository {
             this.pool.execute(replaceStmt, [
                 accountId,
                 episodeId,
-                date,
+                payload.start,
                 'ALL',
                 'age_sum',
                 payload.genderedCounts.counts.NOT_SPECIFIED,
@@ -318,7 +317,6 @@ class SpotifyRepository {
 
     async storePodcastAggregate(
         accountId: number,
-        date: string,
         payload: SpotifyPodcastAggregatePayload
     ): Promise<any> {
         const replaceStmt = `REPLACE INTO spotifyPodcastAggregate (account_id, spa_date, spa_facet, spa_facet_type, 
@@ -336,7 +334,7 @@ class SpotifyRepository {
                         payload.ageFacetedCounts[ageGroup]
                     return await this.pool.execute(replaceStmt, [
                         accountId,
-                        date,
+                        payload.start,
                         ageGroup,
                         'age',
                         entry.counts.NOT_SPECIFIED,
@@ -351,7 +349,7 @@ class SpotifyRepository {
                     const entry = countryFacetedCounts[country]
                     return await this.pool.execute(replaceStmt, [
                         accountId,
-                        date,
+                        payload.start,
                         entry.countryCode,
                         'country',
                         entry.counts.NOT_SPECIFIED,
@@ -363,7 +361,7 @@ class SpotifyRepository {
             ),
             this.pool.execute(replaceStmt, [
                 accountId,
-                date,
+                payload.start,
                 'ALL',
                 'age_sum',
                 payload.genderedCounts.counts.NOT_SPECIFIED,

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { QueryLoader } from './db/QueryLoader'
 import { AnalyticsRepository } from './db/AnalyticsRepository'
 import { AnalyticsApi } from './api/AnalyticsApi'
 import { formatDate, nowString } from './utils/dateHelpers'
+import { AccountKeyRepository } from './db/AccountKeyRepository'
 
 const config = new Config()
 
@@ -87,6 +88,9 @@ const analyticsApi = new AnalyticsApi(analyticsRepo)
 
 const statusRepo = new StatusRepository(pool)
 const statusApi = new StatusApi(statusRepo)
+
+// Initialize the account key repository
+const accountKeyRepo = new AccountKeyRepository(authPool)
 
 const supportedGenericHosters = {
     podigee: 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ import { AppleRepository } from './db/AppleRepository'
 import { AppleConnector } from './api/connectors/AppleConnector'
 import { AnchorConnector } from './api/connectors/AnchorConnector'
 import { AnchorRepository } from './db/AnchorRepository'
+import { HosterConnector } from './api/connectors/HosterConnector'
+import { HosterRepository } from './db/HosterRepository'
 import { healthCheck, mysqlHealthy } from './healthcheck'
 import mysql from 'mysql2/promise'
 import { unless } from './utils/expressHelpers'
@@ -32,7 +34,6 @@ import { QueryLoader } from './db/QueryLoader'
 import { AnalyticsRepository } from './db/AnalyticsRepository'
 import { AnalyticsApi } from './api/AnalyticsApi'
 import { formatDate, nowString } from './utils/dateHelpers'
-import { AccountKeyRepository } from './db/AccountKeyRepository'
 
 const config = new Config()
 
@@ -87,14 +88,22 @@ const analyticsApi = new AnalyticsApi(analyticsRepo)
 const statusRepo = new StatusRepository(pool)
 const statusApi = new StatusApi(statusRepo)
 
-// Initialize the account key repository
-const accountKeyRepo = new AccountKeyRepository(authPool)
+const supportedGenericHosters = {
+    podigee: 1,
+}
+
+const hosterRepo = new HosterRepository(pool)
+const hosterConnectors: { [key: string]: HosterConnector } = {}
+Object.entries(supportedGenericHosters).forEach(([key, value]) => {
+    hosterConnectors[key] = new HosterConnector(hosterRepo, value)
+})
 
 // parameter map will consist of spotify and apple in the future
 const connectorApi = new ConnectorApi({
     spotify: spotifyConnector,
     apple: appleConnector,
     anchor: anchorConnector,
+    ...hosterConnectors,
 })
 
 // defines all endpoints where auth is not required

--- a/src/schema/anchor/aggregatedPerformance.json
+++ b/src/schema/anchor/aggregatedPerformance.json
@@ -116,7 +116,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/anchor/audienceSize.json
+++ b/src/schema/anchor/audienceSize.json
@@ -99,7 +99,6 @@
         "version",
         "retrieved",
         "meta",
-        "range",
         "data"
     ]
 }

--- a/src/schema/anchor/episodePerformance.json
+++ b/src/schema/anchor/episodePerformance.json
@@ -111,7 +111,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/anchor/episodePlays.json
+++ b/src/schema/anchor/episodePlays.json
@@ -126,7 +126,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/anchor/episodesPage.json
+++ b/src/schema/anchor/episodesPage.json
@@ -127,7 +127,6 @@
         "version",
         "retrieved",
         "meta",
-        "range",
         "data"
     ]
 }

--- a/src/schema/anchor/plays.json
+++ b/src/schema/anchor/plays.json
@@ -122,7 +122,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/anchor/playsByAgeRange.json
+++ b/src/schema/anchor/playsByAgeRange.json
@@ -194,7 +194,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/anchor/playsByApp.json
+++ b/src/schema/anchor/playsByApp.json
@@ -130,7 +130,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/anchor/playsByDevice.json
+++ b/src/schema/anchor/playsByDevice.json
@@ -172,7 +172,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/anchor/playsByGender.json
+++ b/src/schema/anchor/playsByGender.json
@@ -170,7 +170,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/anchor/playsByGeo.json
+++ b/src/schema/anchor/playsByGeo.json
@@ -149,7 +149,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/anchor/playsByGeoCity.json
+++ b/src/schema/anchor/playsByGeoCity.json
@@ -149,7 +149,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/anchor/podcastEpisode.json
+++ b/src/schema/anchor/podcastEpisode.json
@@ -157,7 +157,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/anchor/totalPlays.json
+++ b/src/schema/anchor/totalPlays.json
@@ -97,7 +97,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/anchor/totalPlaysByEpisode.json
+++ b/src/schema/anchor/totalPlaysByEpisode.json
@@ -119,7 +119,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/anchor/uniqueListeners.json
+++ b/src/schema/anchor/uniqueListeners.json
@@ -97,7 +97,6 @@
     "version",
     "retrieved",
     "meta",
-    "range",
     "data"
   ]
 }

--- a/src/schema/connector.json
+++ b/src/schema/connector.json
@@ -20,12 +20,12 @@
           "type": "string"
         },
         "episode": {
-          "type":  "string",
+          "type": "string",
           "nullable": true
         },
         "endpoint": {
           "type": "string"
-        }        
+        }
       },
       "required": [
         "show",
@@ -54,7 +54,6 @@
     "provider",
     "version",
     "retrieved",
-    "meta",
-    "range"
+    "meta"
   ]
 }

--- a/src/schema/hoster/hosterEpisodeMetadata.json
+++ b/src/schema/hoster/hosterEpisodeMetadata.json
@@ -1,0 +1,22 @@
+{
+    "$id": "http://openpodcast.dev/schema/hoster/episodemetadata.schema.json",
+    "title": "Hoster Episode Metadata (e.g. for Podigee)",
+    "type": "object",
+    "properties": {
+        "ep_name": {
+            "type": "string"
+        },
+        "ep_url": {
+            "type": "string"
+        },
+        "ep_release_date": {
+            "type": "string",
+            "format": "date-time"
+        }
+    },
+    "required": [
+        "ep_name",
+        "ep_url",
+        "ep_release_date"
+    ]
+}

--- a/src/schema/hoster/hosterEpisodeMetrics.json
+++ b/src/schema/hoster/hosterEpisodeMetrics.json
@@ -28,6 +28,7 @@
                     "start",
                     "end",
                     "dimension",
+                    "subdimension",
                     "value"
                 ]
             }

--- a/src/schema/hoster/hosterEpisodeMetrics.json
+++ b/src/schema/hoster/hosterEpisodeMetrics.json
@@ -1,0 +1,36 @@
+{
+    "$id": "http://openpodcast.dev/schema/hoster/episodemetrics.schema.json",
+    "title": "Hoster Episode Metrics (e.g. for Podigee)",
+    "type": "object",
+    "properties": {
+        "metrics": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "start": {
+                        "type": "string"
+                    },
+                    "end": {
+                        "type": "string"
+                    },
+                    "dimension": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "number"
+                    },
+                    "subdimension": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "start",
+                    "end",
+                    "dimension",
+                    "value"
+                ]
+            }
+        }
+    }
+}

--- a/src/schema/hoster/hosterPodcastMetadata.json
+++ b/src/schema/hoster/hosterPodcastMetadata.json
@@ -1,0 +1,13 @@
+{
+    "$id": "http://openpodcast.dev/schema/hoster/podcastmetadata.schema.json",
+    "title": "Hoster Podcast Metadata (e.g. for Podigee)",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "name"
+    ]
+}

--- a/src/schema/hoster/hosterPodcastMetrics.json
+++ b/src/schema/hoster/hosterPodcastMetrics.json
@@ -28,6 +28,7 @@
                     "start",
                     "end",
                     "dimension",
+                    "subdimension",
                     "value"
                 ]
             }

--- a/src/schema/hoster/hosterPodcastMetrics.json
+++ b/src/schema/hoster/hosterPodcastMetrics.json
@@ -1,0 +1,36 @@
+{
+    "$id": "http://openpodcast.dev/schema/hoster/podcastmetrics.schema.json",
+    "title": "Hoster Podcast Metrics (e.g. for Podigee)",
+    "type": "object",
+    "properties": {
+        "metrics": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "start": {
+                        "type": "string"
+                    },
+                    "end": {
+                        "type": "string"
+                    },
+                    "dimension": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "number"
+                    },
+                    "subdimension": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "start",
+                    "end",
+                    "dimension",
+                    "value"
+                ]
+            }
+        }
+    }
+}

--- a/src/schema/spotify/aggregate.json
+++ b/src/schema/spotify/aggregate.json
@@ -3,6 +3,14 @@
     "title": "Aggregated Spotify Gender Counts",
     "type": "object",
     "properties": {
+        "start": {
+            "type": "string",
+            "format": "date"
+        },
+        "end": {
+            "type": "string",
+            "format": "date"
+        },
         "count": {
             "type": "number"
         },
@@ -117,6 +125,8 @@
         }
     },
     "required": [
+        "start",
+        "end",
         "count",
         "ageFacetedCounts",
         "genderedCounts"

--- a/src/types/connector.ts
+++ b/src/types/connector.ts
@@ -3,10 +3,10 @@ export interface ConnectorPayload {
         endpoint: string
         episode?: string
     }
-    range: {
+    range?: {
         start: string
         end: string
     }
-    data: Object
+    data: object
     provider: string
 }

--- a/src/types/provider/anchor.ts
+++ b/src/types/provider/anchor.ts
@@ -209,7 +209,7 @@ export interface AnchorConnectorPayload {
         endpoint: string
         episode?: string
     }
-    range: {
+    range?: {
         start: string
         end: string
     }

--- a/src/types/provider/hoster.ts
+++ b/src/types/provider/hoster.ts
@@ -1,0 +1,29 @@
+// Metadata for a podcast from a hoster
+export interface HosterPodcastMetadataPayload {
+    name: string
+}
+
+// Metadata for a single episode from a hoster
+export interface HosterEpisodeMetadataPayload {
+    ep_name: string
+    ep_url: string
+    ep_release_date: string
+}
+
+// A single metric from a hoster
+export interface HosterMetric {
+    start: string
+    end: string
+    dimension: string
+    value: number
+    // Examples for "dimension: subdimension":
+    // - downloads: total,
+    // - clients: PocketCast,
+    // - countries: regions
+    subdimension?: string
+}
+
+// Metrics from a hoster
+export interface HosterMetricsPayload {
+    metrics?: HosterMetric[]
+}

--- a/src/types/provider/hoster.ts
+++ b/src/types/provider/hoster.ts
@@ -20,7 +20,9 @@ export interface HosterMetric {
     // - downloads: total,
     // - clients: PocketCast,
     // - countries: regions
-    subdimension?: string
+    // is mandatory, as even if it not realy needed
+    // as it is valid for a global scale, it is called "total" or "global"
+    subdimension: string
 }
 
 // Metrics from a hoster

--- a/src/types/provider/spotify.ts
+++ b/src/types/provider/spotify.ts
@@ -42,6 +42,8 @@ export interface SpotifyGenderCounts {
 }
 
 export interface SpotifyPodcastAggregatePayload {
+    start: string
+    end: string
     count: number
     ageFacetedCounts: {
         [ageGroup: string]: SpotifyGenderCounts
@@ -61,6 +63,8 @@ export interface SpotifyPodcastAggregatePayload {
 }
 
 export interface SpotifyEpisodeAggregatePayload {
+    start: string
+    end: string
     count: number
     ageFacetedCounts: {
         [ageGroup: string]: SpotifyGenderCounts

--- a/tests/api_e2e/analytics.test.js
+++ b/tests/api_e2e/analytics.test.js
@@ -6,8 +6,8 @@ const auth = require('./authheader')
 
 const baseURL = 'http://localhost:8080'
 
-const account_map = JSON.parse(process.env.ACCOUNTS)
-const podcast_test_id = account_map[Object.keys(account_map)[0]]
+// hardcoded for testing and is set in db_auth_data.sql file
+const podcast_test_id = 3
 
 const path_prefix = `/analytics/v1/${podcast_test_id}/`
 

--- a/tests/api_e2e/hoster.test.js
+++ b/tests/api_e2e/hoster.test.js
@@ -1,0 +1,42 @@
+const request = require('supertest')
+const baseURL = 'http://localhost:8080'
+const hosterPodcastMetadataPayload = require('../../fixtures/hosterPodcastMetadata.json')
+const hosterEpisodeMetadataPayload = require('../../fixtures/hosterEpisodeMetadata.json')
+const hosterPodcastMetricsPayload = require('../../fixtures/hosterPodcastMetrics.json')
+const hosterEpisodeMetricsPayload = require('../../fixtures/hosterEpisodeMetrics.json')
+
+const auth = require('./authheader')
+
+describe('check Connector API with generic hosters', () => {
+    it('should return status 200 when sending proper hoster payload', async () => {
+        const response = await request(baseURL)
+            .post('/connector')
+            .set(auth)
+            .send(hosterPodcastMetadataPayload)
+        expect(response.statusCode).toBe(200)
+    })
+
+    it('should return status 200 when sending proper episode payload', async () => {
+        const response = await request(baseURL)
+            .post('/connector')
+            .set(auth)
+            .send(hosterEpisodeMetadataPayload)
+        expect(response.statusCode).toBe(200)
+    })
+
+    it('should return status 200 when sending proper podcast metrics payload', async () => {
+        const response = await request(baseURL)
+            .post('/connector')
+            .set(auth)
+            .send(hosterPodcastMetricsPayload)
+        expect(response.statusCode).toBe(200)
+    })
+
+    it('should return status 200 when sending proper episode metrics payload', async () => {
+        const response = await request(baseURL)
+            .post('/connector')
+            .set(auth)
+            .send(hosterEpisodeMetricsPayload)
+        expect(response.statusCode).toBe(200)
+    })
+})


### PR DESCRIPTION
Introduce DB support for generic hosts by adding new tables for podcast and episode metadata and metrics.

on the way:
- improve dev environment to run test locally
- simplify db dev setup routines
- put all sql files to one dir to be consistent

ref #176
based on work of #169