### PR TITLE
Handle multiple account IDs with one key

### DIFF
--- a/src/auth/AuthController.test.ts
+++ b/src/auth/AuthController.test.ts
@@ -1,0 +1,300 @@
+import { AuthController } from './AuthController'
+import { AccountKeyRepository } from '../db/AccountKeyRepository'
+import { AuthError } from '../types/api'
+import { Request, Response, NextFunction } from 'express'
+
+// Mock the AccountKeyRepository
+jest.mock('../db/AccountKeyRepository')
+
+describe('AuthController', () => {
+    let authController: AuthController
+    let mockAccountKeyRepository: jest.Mocked<AccountKeyRepository>
+    let mockRequest: Partial<Request>
+    let mockResponse: Partial<Response>
+    let mockNext: jest.MockedFunction<NextFunction>
+
+    beforeEach(() => {
+        mockAccountKeyRepository = {
+            getAccountIdsByKey: jest.fn(),
+        } as any
+
+        authController = new AuthController(mockAccountKeyRepository)
+
+        mockRequest = {
+            headers: {},
+        }
+
+        mockResponse = {
+            locals: {},
+        }
+
+        mockNext = jest.fn()
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('getAccountIds', () => {
+        it('should return array of account IDs for valid Bearer token', async () => {
+            const mockAccountIds = [1, 2, 3]
+            mockAccountKeyRepository.getAccountIdsByKey.mockResolvedValue(
+                mockAccountIds
+            )
+
+            const result = await authController.getAccountIds(
+                'Bearer valid-token-123'
+            )
+
+            expect(result).toEqual([1, 2, 3])
+            expect(
+                mockAccountKeyRepository.getAccountIdsByKey
+            ).toHaveBeenCalledWith('valid-token-123')
+        })
+
+        it('should return single account ID in array', async () => {
+            const mockAccountIds = [42]
+            mockAccountKeyRepository.getAccountIdsByKey.mockResolvedValue(
+                mockAccountIds
+            )
+
+            const result = await authController.getAccountIds(
+                'Bearer single-account-token'
+            )
+
+            expect(result).toEqual([42])
+            expect(
+                mockAccountKeyRepository.getAccountIdsByKey
+            ).toHaveBeenCalledWith('single-account-token')
+        })
+
+        it('should throw AuthError when token does not start with Bearer', async () => {
+            await expect(
+                authController.getAccountIds('invalid-token')
+            ).rejects.toThrow(AuthError)
+
+            await expect(
+                authController.getAccountIds('invalid-token')
+            ).rejects.toThrow('Specified token is not valid')
+
+            expect(
+                mockAccountKeyRepository.getAccountIdsByKey
+            ).not.toHaveBeenCalled()
+        })
+
+        it('should throw AuthError when no account IDs found', async () => {
+            mockAccountKeyRepository.getAccountIdsByKey.mockResolvedValue([])
+
+            await expect(
+                authController.getAccountIds('Bearer nonexistent-token')
+            ).rejects.toThrow(AuthError)
+
+            await expect(
+                authController.getAccountIds('Bearer nonexistent-token')
+            ).rejects.toThrow('Specified token is not valid')
+        })
+
+        it('should handle repository errors', async () => {
+            const dbError = new Error('Database error')
+            mockAccountKeyRepository.getAccountIdsByKey.mockRejectedValue(
+                dbError
+            )
+
+            await expect(
+                authController.getAccountIds('Bearer test-token')
+            ).rejects.toThrow('Database error')
+        })
+
+        it('should remove Bearer prefix correctly', async () => {
+            const mockAccountIds = [1]
+            mockAccountKeyRepository.getAccountIdsByKey.mockResolvedValue(
+                mockAccountIds
+            )
+
+            await authController.getAccountIds('Bearer test-token-with-hyphens')
+
+            expect(
+                mockAccountKeyRepository.getAccountIdsByKey
+            ).toHaveBeenCalledWith('test-token-with-hyphens')
+        })
+
+        it('should handle token with spaces after Bearer', async () => {
+            const mockAccountIds = [1]
+            mockAccountKeyRepository.getAccountIdsByKey.mockResolvedValue(
+                mockAccountIds
+            )
+
+            await authController.getAccountIds('Bearer  token-with-spaces')
+
+            expect(
+                mockAccountKeyRepository.getAccountIdsByKey
+            ).toHaveBeenCalledWith(' token-with-spaces')
+        })
+    })
+
+    describe('handleRequest middleware', () => {
+        it('should set user with accountIds and accountId in response locals', async () => {
+            const mockAccountIds = [1, 2, 3]
+            mockAccountKeyRepository.getAccountIdsByKey.mockResolvedValue(
+                mockAccountIds
+            )
+
+            mockRequest.headers!.authorization = 'Bearer valid-token'
+
+            await authController.handleRequest(
+                mockRequest as Request,
+                mockResponse as Response,
+                mockNext
+            )
+
+            expect(mockResponse.locals!.user).toEqual({
+                accountIds: [1, 2, 3],
+                accountId: 1, // First account ID for backward compatibility
+            })
+            expect(mockNext).toHaveBeenCalledWith()
+        })
+
+        it('should set accountId to first element when multiple account IDs exist', async () => {
+            const mockAccountIds = [42, 99, 123]
+            mockAccountKeyRepository.getAccountIdsByKey.mockResolvedValue(
+                mockAccountIds
+            )
+
+            mockRequest.headers!.authorization = 'Bearer multi-account-token'
+
+            await authController.handleRequest(
+                mockRequest as Request,
+                mockResponse as Response,
+                mockNext
+            )
+
+            expect(mockResponse.locals!.user.accountId).toBe(42)
+            expect(mockResponse.locals!.user.accountIds).toEqual([42, 99, 123])
+        })
+
+        it('should set accountId to undefined when no account IDs exist', async () => {
+            mockAccountKeyRepository.getAccountIdsByKey.mockResolvedValue([])
+
+            mockRequest.headers!.authorization = 'Bearer invalid-token'
+
+            await authController.handleRequest(
+                mockRequest as Request,
+                mockResponse as Response,
+                mockNext
+            )
+
+            // Should call next with AuthError, but let's also check what would be set
+            expect(mockNext).toHaveBeenCalledWith(expect.any(AuthError))
+        })
+
+        it('should call next with AuthError when authorization header is missing', async () => {
+            await authController.handleRequest(
+                mockRequest as Request,
+                mockResponse as Response,
+                mockNext
+            )
+
+            expect(mockNext).toHaveBeenCalledWith(expect.any(AuthError))
+            const error = mockNext.mock.calls[0][0] as unknown as AuthError
+            expect(error.message).toContain('Token format is invalid')
+        })
+
+        it('should call next with AuthError when authorization header is too short', async () => {
+            mockRequest.headers!.authorization = 'Bearer'
+
+            await authController.handleRequest(
+                mockRequest as Request,
+                mockResponse as Response,
+                mockNext
+            )
+
+            expect(mockNext).toHaveBeenCalledWith(expect.any(AuthError))
+        })
+
+        it('should call next with AuthError when authorization header does not start with Bearer', async () => {
+            mockRequest.headers!.authorization = 'Basic token123'
+
+            await authController.handleRequest(
+                mockRequest as Request,
+                mockResponse as Response,
+                mockNext
+            )
+
+            expect(mockNext).toHaveBeenCalledWith(expect.any(AuthError))
+        })
+
+        it('should handle authorization header as array', async () => {
+            const mockAccountIds = [1, 2]
+            mockAccountKeyRepository.getAccountIdsByKey.mockResolvedValue(
+                mockAccountIds
+            )
+
+            mockRequest.headers!.authorization = [
+                'Bearer first-token',
+                'Bearer second-token',
+            ] as any
+
+            await authController.handleRequest(
+                mockRequest as Request,
+                mockResponse as Response,
+                mockNext
+            )
+
+            expect(
+                mockAccountKeyRepository.getAccountIdsByKey
+            ).toHaveBeenCalledWith('first-token')
+            expect(mockResponse.locals!.user).toEqual({
+                accountIds: [1, 2],
+                accountId: 1,
+            })
+        })
+
+        it('should call next with AuthError when getAccountIds throws', async () => {
+            mockAccountKeyRepository.getAccountIdsByKey.mockRejectedValue(
+                new AuthError('Invalid token')
+            )
+
+            mockRequest.headers!.authorization = 'Bearer invalid-token'
+
+            await authController.handleRequest(
+                mockRequest as Request,
+                mockResponse as Response,
+                mockNext
+            )
+
+            expect(mockNext).toHaveBeenCalledWith(expect.any(AuthError))
+        })
+
+        it('should handle empty account IDs array', async () => {
+            mockAccountKeyRepository.getAccountIdsByKey.mockResolvedValue([])
+
+            mockRequest.headers!.authorization = 'Bearer empty-accounts-token'
+
+            await authController.handleRequest(
+                mockRequest as Request,
+                mockResponse as Response,
+                mockNext
+            )
+
+            expect(mockNext).toHaveBeenCalledWith(expect.any(AuthError))
+            const error = mockNext.mock.calls[0][0] as unknown as AuthError
+            expect(error.message).toBe('Specified token is not valid')
+        })
+    })
+
+    describe('getMiddleware', () => {
+        it('should return a middleware function', () => {
+            const middleware = authController.getMiddleware()
+
+            expect(typeof middleware).toBe('function')
+        })
+
+        it('should return the bound handleRequest function', () => {
+            const middleware = authController.getMiddleware()
+
+            // The middleware should be a function that calls handleRequest
+            expect(middleware.name).toBe('bound ')
+            expect(typeof middleware).toBe('function')
+        })
+    })
+})

--- a/src/auth/AuthController.ts
+++ b/src/auth/AuthController.ts
@@ -9,7 +9,7 @@ class AuthController {
         this.accountKeyRepository = accountsKeyRepository
     }
 
-    async getAccountId(authToken: string): Promise<number> {
+    async getAccountIds(authToken: string): Promise<number[]> {
         if (authToken.startsWith('Bearer ') === false) {
             throw new AuthError('Specified token is not valid')
         }
@@ -19,9 +19,10 @@ class AuthController {
 
         // First try to get the account ID from the database
         if (this.accountKeyRepository) {
-            const accountId = await this.accountKeyRepository.getAccountIdByKey(token)
-            if (accountId !== null) {
-                return accountId
+            const accountIds =
+                await this.accountKeyRepository.getAccountIdsByKey(token)
+            if (accountIds.length > 0) {
+                return accountIds
             }
         }
 
@@ -58,9 +59,10 @@ class AuthController {
         try {
             // store the user data in the response object (locals is officially made for this)
             // so we can access this data in the backend when it is stored to the database
-            const accountId = await this.getAccountId(authToken)
+            const accountIds = await this.getAccountIds(authToken)
             res.locals.user = {
-                accountId,
+                accountIds: accountIds, // Store all account IDs
+                accountId: accountIds.length > 0 ? accountIds[0] : undefined, // Store the first account ID
             }
         } catch (err) {
             return next(err)

--- a/src/db/AccountKeyRepository.test.ts
+++ b/src/db/AccountKeyRepository.test.ts
@@ -1,0 +1,207 @@
+import { AccountKeyRepository } from './AccountKeyRepository'
+import { Pool, RowDataPacket } from 'mysql2/promise'
+
+// Mock mysql2/promise
+jest.mock('mysql2/promise')
+
+describe('AccountKeyRepository', () => {
+    let accountKeyRepository: AccountKeyRepository
+    let mockPool: jest.Mocked<Pool>
+
+    beforeEach(() => {
+        mockPool = {
+            execute: jest.fn(),
+        } as any
+
+        accountKeyRepository = new AccountKeyRepository(mockPool)
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('getAccountIdsByKey', () => {
+        it('should return array of account IDs for valid API key', async () => {
+            const mockRows = [
+                { account_id: 1 },
+                { account_id: 2 },
+                { account_id: 3 },
+            ] as RowDataPacket[]
+            mockPool.execute.mockResolvedValue([mockRows, []] as any)
+
+            const result = await accountKeyRepository.getAccountIdsByKey(
+                'valid-key-123'
+            )
+
+            expect(result).toEqual([1, 2, 3])
+            expect(mockPool.execute).toHaveBeenCalledWith(
+                'SELECT account_id FROM apiKeys WHERE key_hash = ?',
+                [expect.any(String)] // The hashed key
+            )
+        })
+
+        it('should return single account ID in array', async () => {
+            const mockRows = [{ account_id: 42 }] as RowDataPacket[]
+            mockPool.execute.mockResolvedValue([mockRows, []] as any)
+
+            const result = await accountKeyRepository.getAccountIdsByKey(
+                'single-account-key'
+            )
+
+            expect(result).toEqual([42])
+        })
+
+        it('should return empty array when no accounts found', async () => {
+            const mockRows: RowDataPacket[] = []
+            mockPool.execute.mockResolvedValue([mockRows, []] as any)
+
+            const result = await accountKeyRepository.getAccountIdsByKey(
+                'nonexistent-key'
+            )
+
+            expect(result).toEqual([])
+        })
+
+        it('should filter out rows with null account_id', async () => {
+            const mockRows = [
+                { account_id: 1 },
+                { account_id: null },
+                { account_id: 2 },
+                { account_id: undefined },
+                { account_id: 3 },
+            ] as RowDataPacket[]
+            mockPool.execute.mockResolvedValue([mockRows, []] as any)
+
+            const result = await accountKeyRepository.getAccountIdsByKey(
+                'mixed-data-key'
+            )
+
+            expect(result).toEqual([1, 2, 3])
+        })
+
+        it('should throw error for empty API key', async () => {
+            await expect(
+                accountKeyRepository.getAccountIdsByKey('')
+            ).rejects.toThrow('Invalid API key')
+
+            expect(mockPool.execute).not.toHaveBeenCalled()
+        })
+
+        it('should throw error for null API key', async () => {
+            await expect(
+                accountKeyRepository.getAccountIdsByKey(null as any)
+            ).rejects.toThrow('Invalid API key')
+
+            expect(mockPool.execute).not.toHaveBeenCalled()
+        })
+
+        it('should throw error for undefined API key', async () => {
+            await expect(
+                accountKeyRepository.getAccountIdsByKey(undefined as any)
+            ).rejects.toThrow('Invalid API key')
+
+            expect(mockPool.execute).not.toHaveBeenCalled()
+        })
+
+        it('should throw error for API key longer than 255 characters', async () => {
+            const longKey = 'a'.repeat(256)
+
+            await expect(
+                accountKeyRepository.getAccountIdsByKey(longKey)
+            ).rejects.toThrow('Invalid API key')
+
+            expect(mockPool.execute).not.toHaveBeenCalled()
+        })
+
+        it('should handle API key exactly 255 characters', async () => {
+            const maxLengthKey = 'a'.repeat(255)
+            const mockRows = [{ account_id: 1 }] as RowDataPacket[]
+            mockPool.execute.mockResolvedValue([mockRows, []] as any)
+
+            const result = await accountKeyRepository.getAccountIdsByKey(
+                maxLengthKey
+            )
+
+            expect(result).toEqual([1])
+            expect(mockPool.execute).toHaveBeenCalled()
+        })
+
+        it('should use hashed key in database query', async () => {
+            const apiKey = 'test-key-123'
+            const mockRows = [{ account_id: 1 }] as RowDataPacket[]
+            mockPool.execute.mockResolvedValue([mockRows, []] as any)
+
+            await accountKeyRepository.getAccountIdsByKey(apiKey)
+
+            expect(mockPool.execute).toHaveBeenCalledWith(
+                'SELECT account_id FROM apiKeys WHERE key_hash = ?',
+                [expect.stringMatching(/^[a-f0-9]{64}$/)] // SHA-256 hash is 64 hex characters
+            )
+        })
+
+        it('should handle database errors', async () => {
+            const dbError = new Error('Database connection failed')
+            mockPool.execute.mockRejectedValue(dbError)
+
+            await expect(
+                accountKeyRepository.getAccountIdsByKey('test-key')
+            ).rejects.toThrow('Database connection failed')
+        })
+
+        it('should handle non-array database response', async () => {
+            mockPool.execute.mockResolvedValue([null as any, []] as any)
+
+            const result = await accountKeyRepository.getAccountIdsByKey(
+                'test-key'
+            )
+
+            expect(result).toEqual([])
+        })
+
+        it('should handle large number of account IDs', async () => {
+            const mockRows = Array.from({ length: 100 }, (_, i) => ({
+                account_id: i + 1,
+            })) as RowDataPacket[]
+            mockPool.execute.mockResolvedValue([mockRows, []] as any)
+
+            const result = await accountKeyRepository.getAccountIdsByKey(
+                'multi-account-key'
+            )
+
+            expect(result).toHaveLength(100)
+            expect(result).toEqual(Array.from({ length: 100 }, (_, i) => i + 1))
+        })
+    })
+
+    describe('hashKey', () => {
+        it('should produce consistent hashes for same input', async () => {
+            const apiKey = 'test-key-123'
+            const mockRows1 = [{ account_id: 1 }] as RowDataPacket[]
+            const mockRows2 = [{ account_id: 1 }] as RowDataPacket[]
+
+            mockPool.execute.mockResolvedValueOnce([mockRows1, []] as any)
+            mockPool.execute.mockResolvedValueOnce([mockRows2, []] as any)
+
+            await accountKeyRepository.getAccountIdsByKey(apiKey)
+            const firstCallHash = mockPool.execute.mock.calls[0][1][0]
+
+            await accountKeyRepository.getAccountIdsByKey(apiKey)
+            const secondCallHash = mockPool.execute.mock.calls[1][1][0]
+
+            expect(firstCallHash).toBe(secondCallHash)
+        })
+
+        it('should produce different hashes for different inputs', async () => {
+            const mockRows = [{ account_id: 1 }] as RowDataPacket[]
+            mockPool.execute.mockResolvedValue([mockRows, []] as any)
+
+            await accountKeyRepository.getAccountIdsByKey('key1')
+            const hash1 = mockPool.execute.mock.calls[0][1][0]
+
+            await accountKeyRepository.getAccountIdsByKey('key2')
+            const hash2 = mockPool.execute.mock.calls[1][1][0]
+
+            expect(hash1).not.toBe(hash2)
+        })
+    })
+})

--- a/src/db/AccountKeyRepository.ts
+++ b/src/db/AccountKeyRepository.ts
@@ -10,12 +10,12 @@ class AccountKeyRepository {
     }
 
     /**
-     * Get account ID by API key
+     * Get account IDs by API key
      *
      * @param apiKey The API key to lookup
-     * @returns Account ID if found, null otherwise
+     * @returns Array of account IDs if found, empty array otherwise
      */
-    async getAccountIdByKey(apiKey: string): Promise<number | null> {
+    async getAccountIdsByKey(apiKey: string): Promise<number[]> {
         if (!apiKey || apiKey.length === 0 || apiKey.length > 255) {
             throw new Error('Invalid API key')
         }
@@ -26,11 +26,13 @@ class AccountKeyRepository {
             [hashedKey]
         )
 
-        if (!Array.isArray(rows) || rows.length !== 1 || !rows[0].account_id) {
-            return null // No account found for this key
+        if (!Array.isArray(rows) || rows.length === 0) {
+            return [] // No accounts found for this key
         }
 
-        return rows[0].account_id as number
+        return rows
+            .filter((row) => row.account_id)
+            .map((row) => row.account_id as number)
     }
 
     /**


### PR DESCRIPTION
Enhance the API to retrieve multiple account IDs associated with a single API key, updating relevant methods and ensuring backward compatibility. Adjust error handling and response structures accordingly.