### PR TITLE
Add user registration API endpoint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,12 @@ module.exports = {
         sourceType: 'module',
         project: './tsconfig.json',
     },
+    ignorePatterns: [
+        '**/*.test.ts',
+        '**/*.spec.ts',
+        'tests/**/*',
+        'dist/**/*'
+    ],
     rules: {
         'prettier/prettier': ['error'],
     },

--- a/db_schema/migrations/15_user_registration.sql
+++ b/db_schema/migrations/15_user_registration.sql
@@ -1,0 +1,18 @@
+-- Migration: Add user registration tables
+-- Migration ID: 15
+
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTO_INCREMENT,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_email (email)
+);
+
+-- Note: Foreign key constraint between apiKeys.account_id and users.id
+-- cannot be implemented due to cross-database limitations (apiKeys is in openpodcast_auth database)
+-- The relationship is maintained programmatically in the application code
+
+-- Update migrations table
+INSERT INTO migrations (migration_id, migration_name) VALUES (15, 'user_registration');

--- a/db_schema/schema.sql
+++ b/db_schema/schema.sql
@@ -17,8 +17,18 @@ CREATE TABLE IF NOT EXISTS migrations (
 -- -----------------------------------------
 -- IMPORTANT: this is the schema version
 -- ID has to be incremented for each change
-INSERT INTO migrations (migration_id, migration_name) VALUES (14, 'genericHoster');
+INSERT INTO migrations (migration_id, migration_name) VALUES (15, 'user_registration');
 -- -----------------------------------------
+
+-- User registration table (introduced by migration 15)
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTO_INCREMENT,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_email (email)
+);
 
 CREATE TABLE IF NOT EXISTS events (
   account_id INTEGER NOT NULL,

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,8 @@ module.exports = {
   },
   testMatch: [
     '**/__tests__/**/*.ts',
-    '**/?(*.)+(spec|test).ts'
+    '**/?(*.)+(spec|test).ts',
+    '**/tests/api_e2e/**/*.js'
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
 }

--- a/src/api/RegistrationApi.test.ts
+++ b/src/api/RegistrationApi.test.ts
@@ -1,0 +1,216 @@
+import { RegistrationApi, RegisterRequest } from './RegistrationApi'
+import { UserRepository, User } from '../db/UserRepository'
+import { AccountKeyRepository } from '../db/AccountKeyRepository'
+
+jest.mock('../db/UserRepository')
+jest.mock('../db/AccountKeyRepository')
+
+const MockedUserRepository = UserRepository as jest.MockedClass<typeof UserRepository>
+const MockedAccountKeyRepository = AccountKeyRepository as jest.MockedClass<typeof AccountKeyRepository>
+
+describe('RegistrationApi', () => {
+    let registrationApi: RegistrationApi
+    let mockUserRepo: jest.Mocked<UserRepository>
+    let mockAccountKeyRepo: jest.Mocked<AccountKeyRepository>
+
+    beforeEach(() => {
+        mockUserRepo = new MockedUserRepository({} as any) as jest.Mocked<UserRepository>
+        mockAccountKeyRepo = new MockedAccountKeyRepository({} as any) as jest.Mocked<AccountKeyRepository>
+        registrationApi = new RegistrationApi(mockUserRepo, mockAccountKeyRepo)
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('register', () => {
+        const validRequest: RegisterRequest = {
+            name: 'John Doe',
+            email: 'john@example.com'
+        }
+
+        it('should register a new user successfully', async () => {
+            const mockUser: User = {
+                id: 1,
+                name: 'John Doe',
+                email: 'john@example.com',
+                created_at: '2023-01-01T00:00:00.000Z',
+                updated_at: '2023-01-01T00:00:00.000Z'
+            }
+
+            mockUserRepo.getUserByEmail.mockResolvedValue(null)
+            mockUserRepo.createUser.mockResolvedValue(mockUser)
+            mockAccountKeyRepo.generateApiKey.mockResolvedValue('op_1234567890abcdef1234567890abcdef')
+
+            const result = await registrationApi.register(validRequest)
+
+            expect(result.statusCode).toBe(201)
+            expect(result.response.success).toBe(true)
+            expect(result.response.data).toEqual({
+                userId: 1,
+                apiKey: 'op_1234567890abcdef1234567890abcdef',
+                email: 'john@example.com',
+                name: 'John Doe'
+            })
+
+            expect(mockUserRepo.getUserByEmail).toHaveBeenCalledWith('john@example.com')
+            expect(mockUserRepo.createUser).toHaveBeenCalledWith('John Doe', 'john@example.com')
+            expect(mockAccountKeyRepo.generateApiKey).toHaveBeenCalledWith(1)
+        })
+
+        it('should return existing user data when email already exists', async () => {
+            const existingUser: User = {
+                id: 2,
+                name: 'Jane Doe',
+                email: 'john@example.com',
+                created_at: '2023-01-01T00:00:00.000Z',
+                updated_at: '2023-01-01T00:00:00.000Z'
+            }
+
+            mockUserRepo.getUserByEmail.mockResolvedValue(existingUser)
+            mockAccountKeyRepo.getApiKeyHashByAccountId.mockResolvedValue('hash123')
+            mockAccountKeyRepo.generateApiKey.mockResolvedValue('op_existingkey1234567890abcdef123456')
+
+            const result = await registrationApi.register(validRequest)
+
+            expect(result.statusCode).toBe(409)
+            expect(result.response.success).toBe(false)
+            expect(result.response.error).toBe('Email already registered')
+            expect(result.response.data).toEqual({
+                userId: 2,
+                apiKey: 'op_existingkey1234567890abcdef123456',
+                email: 'john@example.com',
+                name: 'Jane Doe'
+            })
+
+            expect(mockUserRepo.createUser).not.toHaveBeenCalled()
+        })
+
+        it('should return validation error for missing name', async () => {
+            const invalidRequest = {
+                name: '',
+                email: 'john@example.com'
+            }
+
+            const result = await registrationApi.register(invalidRequest)
+
+            expect(result.statusCode).toBe(400)
+            expect(result.response.success).toBe(false)
+            expect(result.response.error).toBe('Validation failed')
+            expect(result.response.details).toContain('Name is required')
+        })
+
+        it('should return validation error for missing email', async () => {
+            const invalidRequest = {
+                name: 'John Doe',
+                email: ''
+            }
+
+            const result = await registrationApi.register(invalidRequest)
+
+            expect(result.statusCode).toBe(400)
+            expect(result.response.success).toBe(false)
+            expect(result.response.error).toBe('Validation failed')
+            expect(result.response.details).toContain('Email is required')
+        })
+
+        it('should return validation error for invalid email format', async () => {
+            const invalidRequest = {
+                name: 'John Doe',
+                email: 'invalid-email'
+            }
+
+            const result = await registrationApi.register(invalidRequest)
+
+            expect(result.statusCode).toBe(400)
+            expect(result.response.success).toBe(false)
+            expect(result.response.error).toBe('Validation failed')
+            expect(result.response.details).toContain('Email must be valid')
+        })
+
+        it('should return validation error for name too short', async () => {
+            const invalidRequest = {
+                name: 'A',
+                email: 'john@example.com'
+            }
+
+            const result = await registrationApi.register(invalidRequest)
+
+            expect(result.statusCode).toBe(400)
+            expect(result.response.success).toBe(false)
+            expect(result.response.error).toBe('Validation failed')
+            expect(result.response.details).toContain('Name must be between 2 and 100 characters')
+        })
+
+        it('should return validation error for name too long', async () => {
+            const invalidRequest = {
+                name: 'A'.repeat(101),
+                email: 'john@example.com'
+            }
+
+            const result = await registrationApi.register(invalidRequest)
+
+            expect(result.statusCode).toBe(400)
+            expect(result.response.success).toBe(false)
+            expect(result.response.error).toBe('Validation failed')
+            expect(result.response.details).toContain('Name must be between 2 and 100 characters')
+        })
+
+        it('should normalize email to lowercase', async () => {
+            const requestWithUppercaseEmail = {
+                name: 'John Doe',
+                email: 'JOHN@EXAMPLE.COM'
+            }
+
+            const mockUser: User = {
+                id: 1,
+                name: 'John Doe',
+                email: 'john@example.com',
+                created_at: '2023-01-01T00:00:00.000Z',
+                updated_at: '2023-01-01T00:00:00.000Z'
+            }
+
+            mockUserRepo.getUserByEmail.mockResolvedValue(null)
+            mockUserRepo.createUser.mockResolvedValue(mockUser)
+            mockAccountKeyRepo.generateApiKey.mockResolvedValue('op_1234567890abcdef1234567890abcdef')
+
+            await registrationApi.register(requestWithUppercaseEmail)
+
+            expect(mockUserRepo.getUserByEmail).toHaveBeenCalledWith('john@example.com')
+            expect(mockUserRepo.createUser).toHaveBeenCalledWith('John Doe', 'john@example.com')
+        })
+
+        it('should trim whitespace from name', async () => {
+            const requestWithWhitespace = {
+                name: '  John Doe  ',
+                email: 'john@example.com'
+            }
+
+            const mockUser: User = {
+                id: 1,
+                name: 'John Doe',
+                email: 'john@example.com',
+                created_at: '2023-01-01T00:00:00.000Z',
+                updated_at: '2023-01-01T00:00:00.000Z'
+            }
+
+            mockUserRepo.getUserByEmail.mockResolvedValue(null)
+            mockUserRepo.createUser.mockResolvedValue(mockUser)
+            mockAccountKeyRepo.generateApiKey.mockResolvedValue('op_1234567890abcdef1234567890abcdef')
+
+            await registrationApi.register(requestWithWhitespace)
+
+            expect(mockUserRepo.createUser).toHaveBeenCalledWith('John Doe', 'john@example.com')
+        })
+
+        it('should handle database errors gracefully', async () => {
+            mockUserRepo.getUserByEmail.mockRejectedValue(new Error('Database error'))
+
+            const result = await registrationApi.register(validRequest)
+
+            expect(result.statusCode).toBe(500)
+            expect(result.response.success).toBe(false)
+            expect(result.response.error).toBe('Internal server error')
+        })
+    })
+})

--- a/src/api/RegistrationApi.ts
+++ b/src/api/RegistrationApi.ts
@@ -1,0 +1,166 @@
+import { UserRepository } from '../db/UserRepository'
+import { AccountKeyRepository } from '../db/AccountKeyRepository'
+
+export interface RegisterRequest {
+    name: string
+    email: string
+}
+
+export interface RegisterResponse {
+    success: boolean
+    data?: {
+        userId: number
+        apiKey: string
+        email: string
+        name: string
+    }
+    error?: string
+    details?: string[]
+}
+
+export class RegistrationApi {
+    private userRepo: UserRepository
+    private accountKeyRepo: AccountKeyRepository
+
+    constructor(
+        userRepo: UserRepository,
+        accountKeyRepo: AccountKeyRepository
+    ) {
+        this.userRepo = userRepo
+        this.accountKeyRepo = accountKeyRepo
+    }
+
+    async register(
+        data: RegisterRequest
+    ): Promise<{ response: RegisterResponse; statusCode: number }> {
+        const validation = this.validateInput(data)
+        if (!validation.isValid) {
+            return {
+                response: {
+                    success: false,
+                    error: 'Validation failed',
+                    details: validation.errors,
+                },
+                statusCode: 400,
+            }
+        }
+
+        const { name, email } = data
+        const normalizedEmail = email.toLowerCase().trim()
+        const trimmedName = name.trim()
+
+        try {
+            const existingUser = await this.userRepo.getUserByEmail(
+                normalizedEmail
+            )
+
+            if (existingUser) {
+                let apiKey = await this.getExistingApiKey(existingUser.id)
+                if (!apiKey) {
+                    apiKey = await this.accountKeyRepo.generateApiKey(
+                        existingUser.id
+                    )
+                }
+
+                return {
+                    response: {
+                        success: false,
+                        error: 'Email already registered',
+                        data: {
+                            userId: existingUser.id,
+                            apiKey,
+                            email: existingUser.email,
+                            name: existingUser.name,
+                        },
+                    },
+                    statusCode: 409,
+                }
+            }
+
+            const newUser = await this.userRepo.createUser(
+                trimmedName,
+                normalizedEmail
+            )
+            const apiKey = await this.accountKeyRepo.generateApiKey(newUser.id)
+
+            return {
+                response: {
+                    success: true,
+                    data: {
+                        userId: newUser.id,
+                        apiKey,
+                        email: newUser.email,
+                        name: newUser.name,
+                    },
+                },
+                statusCode: 201,
+            }
+        } catch (error) {
+            console.error('Registration error:', error)
+            return {
+                response: {
+                    success: false,
+                    error: 'Internal server error',
+                },
+                statusCode: 500,
+            }
+        }
+    }
+
+    private validateInput(data: RegisterRequest): {
+        isValid: boolean
+        errors: string[]
+    } {
+        const errors: string[] = []
+
+        if (
+            !data.name ||
+            typeof data.name !== 'string' ||
+            data.name.trim().length === 0
+        ) {
+            errors.push('Name is required')
+        } else if (
+            data.name.trim().length < 2 ||
+            data.name.trim().length > 100
+        ) {
+            errors.push('Name must be between 2 and 100 characters')
+        }
+
+        if (
+            !data.email ||
+            typeof data.email !== 'string' ||
+            data.email.trim().length === 0
+        ) {
+            errors.push('Email is required')
+        } else if (!this.isValidEmail(data.email.trim())) {
+            errors.push('Email must be valid')
+        }
+
+        return {
+            isValid: errors.length === 0,
+            errors,
+        }
+    }
+
+    private isValidEmail(email: string): boolean {
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+        return emailRegex.test(email)
+    }
+
+    private async getExistingApiKey(userId: number): Promise<string | null> {
+        const keyHash = await this.accountKeyRepo.getApiKeyHashByAccountId(
+            userId
+        )
+        if (!keyHash) {
+            return null
+        }
+
+        return this.generateNewApiKeyForExistingUser(userId)
+    }
+
+    private async generateNewApiKeyForExistingUser(
+        userId: number
+    ): Promise<string> {
+        return await this.accountKeyRepo.generateApiKey(userId)
+    }
+}

--- a/src/db/UserRepository.test.ts
+++ b/src/db/UserRepository.test.ts
@@ -1,0 +1,166 @@
+import { UserRepository, User } from './UserRepository'
+import { Pool, RowDataPacket, ResultSetHeader } from 'mysql2/promise'
+
+jest.mock('mysql2/promise')
+
+describe('UserRepository', () => {
+    let userRepo: UserRepository
+    let mockPool: jest.Mocked<Pool>
+
+    beforeEach(() => {
+        mockPool = {
+            execute: jest.fn()
+        } as any
+
+        userRepo = new UserRepository(mockPool)
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('getUserByEmail', () => {
+        it('should return user when found', async () => {
+            const mockUser = {
+                id: 1,
+                email: 'john@example.com',
+                name: 'John Doe',
+                created_at: '2023-01-01T00:00:00.000Z',
+                updated_at: '2023-01-01T00:00:00.000Z'
+            }
+
+            const mockRows: RowDataPacket[] = [mockUser as RowDataPacket]
+            mockPool.execute.mockResolvedValue([mockRows])
+
+            const result = await userRepo.getUserByEmail('john@example.com')
+
+            expect(result).toEqual(mockUser)
+            expect(mockPool.execute).toHaveBeenCalledWith(
+                'SELECT id, email, name, created_at, updated_at FROM users WHERE email = ?',
+                ['john@example.com']
+            )
+        })
+
+        it('should return null when user not found', async () => {
+            const mockRows: RowDataPacket[] = []
+            mockPool.execute.mockResolvedValue([mockRows])
+
+            const result = await userRepo.getUserByEmail('notfound@example.com')
+
+            expect(result).toBeNull()
+        })
+
+        it('should normalize email to lowercase', async () => {
+            const mockRows: RowDataPacket[] = []
+            mockPool.execute.mockResolvedValue([mockRows])
+
+            await userRepo.getUserByEmail('JOHN@EXAMPLE.COM')
+
+            expect(mockPool.execute).toHaveBeenCalledWith(
+                'SELECT id, email, name, created_at, updated_at FROM users WHERE email = ?',
+                ['john@example.com']
+            )
+        })
+    })
+
+    describe('createUser', () => {
+        it('should create user successfully', async () => {
+            const mockResult: ResultSetHeader = {
+                insertId: 1,
+                affectedRows: 1,
+                changedRows: 1,
+                fieldCount: 0,
+                info: '',
+                serverStatus: 0,
+                warningStatus: 0
+            }
+
+            const mockUser = {
+                id: 1,
+                email: 'john@example.com',
+                name: 'John Doe',
+                created_at: '2023-01-01T00:00:00.000Z',
+                updated_at: '2023-01-01T00:00:00.000Z'
+            }
+
+            mockPool.execute
+                .mockResolvedValueOnce([mockResult]) // INSERT
+                .mockResolvedValueOnce([[mockUser as RowDataPacket]]) // SELECT
+
+            const result = await userRepo.createUser('John Doe', 'john@example.com')
+
+            expect(result).toEqual(mockUser)
+            expect(mockPool.execute).toHaveBeenCalledWith(
+                'INSERT INTO users (name, email) VALUES (?, ?)',
+                ['John Doe', 'john@example.com']
+            )
+        })
+
+        it('should normalize email to lowercase and trim name', async () => {
+            const mockResult: ResultSetHeader = {
+                insertId: 1,
+                affectedRows: 1,
+                changedRows: 1,
+                fieldCount: 0,
+                info: '',
+                serverStatus: 0,
+                warningStatus: 0
+            }
+
+            const mockUser = {
+                id: 1,
+                email: 'john@example.com',
+                name: 'John Doe',
+                created_at: '2023-01-01T00:00:00.000Z',
+                updated_at: '2023-01-01T00:00:00.000Z'
+            }
+
+            mockPool.execute
+                .mockResolvedValueOnce([mockResult])
+                .mockResolvedValueOnce([[mockUser as RowDataPacket]])
+
+            await userRepo.createUser('  John Doe  ', 'JOHN@EXAMPLE.COM')
+
+            expect(mockPool.execute).toHaveBeenCalledWith(
+                'INSERT INTO users (name, email) VALUES (?, ?)',
+                ['John Doe', 'john@example.com']
+            )
+        })
+
+        it('should throw error when insertId is not available', async () => {
+            const mockResult: ResultSetHeader = {
+                insertId: 0,
+                affectedRows: 1,
+                changedRows: 1,
+                fieldCount: 0,
+                info: '',
+                serverStatus: 0,
+                warningStatus: 0
+            }
+
+            mockPool.execute.mockResolvedValue([mockResult])
+
+            await expect(userRepo.createUser('John Doe', 'john@example.com'))
+                .rejects.toThrow('Failed to create user')
+        })
+
+        it('should throw error when created user cannot be retrieved', async () => {
+            const mockResult: ResultSetHeader = {
+                insertId: 1,
+                affectedRows: 1,
+                changedRows: 1,
+                fieldCount: 0,
+                info: '',
+                serverStatus: 0,
+                warningStatus: 0
+            }
+
+            mockPool.execute
+                .mockResolvedValueOnce([mockResult])
+                .mockResolvedValueOnce([[]])
+
+            await expect(userRepo.createUser('John Doe', 'john@example.com'))
+                .rejects.toThrow('Failed to retrieve created user')
+        })
+    })
+})

--- a/src/db/UserRepository.ts
+++ b/src/db/UserRepository.ts
@@ -1,0 +1,61 @@
+import { Pool, RowDataPacket, ResultSetHeader } from 'mysql2/promise'
+
+export interface User {
+    id: number
+    email: string
+    name: string
+    created_at: string
+    updated_at: string
+}
+
+export class UserRepository {
+    private pool: Pool
+
+    constructor(pool: Pool) {
+        this.pool = pool
+    }
+
+    async getUserByEmail(email: string): Promise<User | null> {
+        const [rows] = await this.pool.execute<RowDataPacket[]>(
+            'SELECT id, email, name, created_at, updated_at FROM users WHERE email = ?',
+            [email.toLowerCase()]
+        )
+
+        if (!Array.isArray(rows) || rows.length === 0) {
+            return null
+        }
+
+        return rows[0] as User
+    }
+
+    async createUser(name: string, email: string): Promise<User> {
+        const [result] = await this.pool.execute<ResultSetHeader>(
+            'INSERT INTO users (name, email) VALUES (?, ?)',
+            [name.trim(), email.toLowerCase()]
+        )
+
+        if (!result.insertId) {
+            throw new Error('Failed to create user')
+        }
+
+        const user = await this.getUserById(result.insertId)
+        if (!user) {
+            throw new Error('Failed to retrieve created user')
+        }
+
+        return user
+    }
+
+    private async getUserById(id: number): Promise<User | null> {
+        const [rows] = await this.pool.execute<RowDataPacket[]>(
+            'SELECT id, email, name, created_at, updated_at FROM users WHERE id = ?',
+            [id]
+        )
+
+        if (!Array.isArray(rows) || rows.length === 0) {
+            return null
+        }
+
+        return rows[0] as User
+    }
+}

--- a/tests/api_e2e/registration.test.js
+++ b/tests/api_e2e/registration.test.js
@@ -1,0 +1,223 @@
+const request = require('supertest')
+const baseURL = 'http://localhost:8080'
+
+describe('User Registration API', () => {
+    const validUserData = {
+        name: 'John Doe',
+        email: 'john.doe@example.com'
+    }
+
+    describe('POST /register - Successful Registration', () => {
+        it('should register a new user successfully', async () => {
+            const uniqueEmail = `test-${Date.now()}@example.com`
+            const userData = {
+                name: 'Test User',
+                email: uniqueEmail
+            }
+
+            const response = await request(baseURL)
+                .post('/register')
+                .send(userData)
+
+            expect(response.statusCode).toBe(201)
+            expect(response.body).toMatchObject({
+                success: true,
+                data: {
+                    userId: expect.any(Number),
+                    apiKey: expect.stringMatching(/^op_[a-f0-9]{32}$/),
+                    email: uniqueEmail,
+                    name: 'Test User'
+                }
+            })
+        })
+    })
+
+    describe('POST /register - Duplicate Email', () => {
+        it('should return existing user data when email already exists', async () => {
+            const existingEmail = `existing-${Date.now()}@example.com`
+            const userData = {
+                name: 'First User',
+                email: existingEmail
+            }
+
+            // First registration
+            const firstResponse = await request(baseURL)
+                .post('/register')
+                .send(userData)
+
+            expect(firstResponse.statusCode).toBe(201)
+
+            // Second registration with same email
+            const secondResponse = await request(baseURL)
+                .post('/register')
+                .send({
+                    name: 'Second User',
+                    email: existingEmail
+                })
+
+            expect(secondResponse.statusCode).toBe(409)
+            expect(secondResponse.body).toMatchObject({
+                success: false,
+                error: 'Email already registered',
+                data: {
+                    userId: expect.any(Number),
+                    apiKey: expect.stringMatching(/^op_[a-f0-9]{32}$/),
+                    email: existingEmail,
+                    name: 'First User' // Should maintain original name
+                }
+            })
+        })
+    })
+
+    describe('POST /register - Validation Errors', () => {
+        it('should return 400 for missing name', async () => {
+            const response = await request(baseURL)
+                .post('/register')
+                .send({
+                    email: 'test@example.com'
+                })
+
+            expect(response.statusCode).toBe(400)
+            expect(response.body).toMatchObject({
+                success: false,
+                error: 'Validation failed',
+                details: expect.arrayContaining([
+                    expect.stringContaining('Name')
+                ])
+            })
+        })
+
+        it('should return 400 for missing email', async () => {
+            const response = await request(baseURL)
+                .post('/register')
+                .send({
+                    name: 'Test User'
+                })
+
+            expect(response.statusCode).toBe(400)
+            expect(response.body).toMatchObject({
+                success: false,
+                error: 'Validation failed',
+                details: expect.arrayContaining([
+                    expect.stringContaining('Email')
+                ])
+            })
+        })
+
+        it('should return 400 for invalid email format', async () => {
+            const response = await request(baseURL)
+                .post('/register')
+                .send({
+                    name: 'Test User',
+                    email: 'invalid-email'
+                })
+
+            expect(response.statusCode).toBe(400)
+            expect(response.body).toMatchObject({
+                success: false,
+                error: 'Validation failed',
+                details: expect.arrayContaining([
+                    expect.stringContaining('Email')
+                ])
+            })
+        })
+
+        it('should return 400 for name too short', async () => {
+            const response = await request(baseURL)
+                .post('/register')
+                .send({
+                    name: 'A',
+                    email: 'test@example.com'
+                })
+
+            expect(response.statusCode).toBe(400)
+            expect(response.body).toMatchObject({
+                success: false,
+                error: 'Validation failed',
+                details: expect.arrayContaining([
+                    expect.stringContaining('Name')
+                ])
+            })
+        })
+
+        it('should return 400 for name too long', async () => {
+            const longName = 'A'.repeat(101)
+            const response = await request(baseURL)
+                .post('/register')
+                .send({
+                    name: longName,
+                    email: 'test@example.com'
+                })
+
+            expect(response.statusCode).toBe(400)
+            expect(response.body).toMatchObject({
+                success: false,
+                error: 'Validation failed',
+                details: expect.arrayContaining([
+                    expect.stringContaining('Name')
+                ])
+            })
+        })
+
+        it('should return 400 for empty JSON body', async () => {
+            const response = await request(baseURL)
+                .post('/register')
+                .send({})
+
+            expect(response.statusCode).toBe(400)
+            expect(response.body).toMatchObject({
+                success: false,
+                error: 'Validation failed'
+            })
+        })
+    })
+
+    describe('POST /register - Data Normalization', () => {
+        it('should normalize email to lowercase', async () => {
+            const uniqueEmail = `TEST-${Date.now()}@EXAMPLE.COM`
+            const userData = {
+                name: 'Test User',
+                email: uniqueEmail
+            }
+
+            const response = await request(baseURL)
+                .post('/register')
+                .send(userData)
+
+            expect(response.statusCode).toBe(201)
+            expect(response.body.data.email).toBe(uniqueEmail.toLowerCase())
+        })
+
+        it('should trim whitespace from name', async () => {
+            const uniqueEmail = `test-${Date.now()}@example.com`
+            const userData = {
+                name: '  Test User  ',
+                email: uniqueEmail
+            }
+
+            const response = await request(baseURL)
+                .post('/register')
+                .send(userData)
+
+            expect(response.statusCode).toBe(201)
+            expect(response.body.data.name).toBe('Test User')
+        })
+    })
+
+    describe('POST /register - API Key Format', () => {
+        it('should generate API key with correct format', async () => {
+            const uniqueEmail = `test-${Date.now()}@example.com`
+            const userData = {
+                name: 'Test User',
+                email: uniqueEmail
+            }
+
+            const response = await request(baseURL)
+                .post('/register')
+                .send(userData)
+
+            expect(response.statusCode).toBe(201)
+            expect(response.body.data.apiKey).toMatch(/^op_[a-f0-9]{32}$/)
+        })
+    })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -91,5 +91,10 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
-  }
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "tests/**/*"
+  ]
 }


### PR DESCRIPTION
Related to https://github.com/openpodcast/landing/pull/15

Adds POST /register endpoint for user registration with automatic API key generation.

Features:
- User registration with name and email validation
- Automatic API key generation (op_ prefix format)  
- Duplicate email handling (returns existing user data with 409)
- Database migration for users table
- Comprehensive unit and E2E tests
- Updated Jest config to support both TypeScript and JavaScript tests

The endpoint is public (no auth required) and integrates with the existing auth system using the openpodcast_auth.apiKeys table.