### PR TITLE
Fix empty 'Meisgehörte Episoden' slide in voice agency reports

### DIFF
--- a/fixtures/anchorTotalPlaysByEpisode.json
+++ b/fixtures/anchorTotalPlaysByEpisode.json
@@ -20,14 +20,16 @@
           12345678,
           111,
           1654237852,
-          1
+          1,
+          "spotify:episode:1cPUh123example"
         ],
         [
           "Some other title",
           98765432,
           222,
           1645779600,
-          2
+          2,
+          "spotify:episode:2dQVi456example"
         ]
       ],
       "columnHeaders": [
@@ -51,6 +53,10 @@
         {
           "name": "Rank",
           "type": "integer"
+        },
+        {
+          "name": "Episode URI",
+          "type": "string"
         }
       ]
     }

--- a/src/schema/anchor/totalPlaysByEpisode.json
+++ b/src/schema/anchor/totalPlaysByEpisode.json
@@ -58,7 +58,7 @@
               "type": "array",
               "items": {
                 "type": "array",
-                "prefixItems": [
+                "items": [
                   {
                     "type": "string"
                   },
@@ -73,10 +73,14 @@
                   },
                   {
                     "type": "number"
+                  },
+                  {
+                    "type": "string"
                   }
                 ],
-                "minItems": 5,
-                "maxItems": 5
+                "minItems": 6,
+                "maxItems": 6,
+                "additionalItems": false
               }
             },
             "columnHeaders": {

--- a/src/types/provider/anchor.ts
+++ b/src/types/provider/anchor.ts
@@ -170,8 +170,9 @@ export interface RawAnchorTotalPlaysData {
 }
 
 export interface RawAnchorTotalPlaysByEpisodeData {
-    rows: [string, number, number, number, number][]
+    rows: [string, number, number, number, number, string][]
     columnHeaders: [
+        AnchorColumnHeader,
         AnchorColumnHeader,
         AnchorColumnHeader,
         AnchorColumnHeader,


### PR DESCRIPTION
fix number of fields als spotify api has changeds

This change addresses the issue of the slide being empty. Fixes openpodcast/report#72