### PR TITLE
Add Spotify episode aggregate handling with date validation

### DIFF
--- a/fixtures/spotifyEpisodeAggregateNoDateRange.json
+++ b/fixtures/spotifyEpisodeAggregateNoDateRange.json
@@ -1,0 +1,91 @@
+{
+    "provider": "spotify",
+    "version": 1,
+    "retrieved": "2025-08-25T21:51:31.292575",
+    "meta": {
+        "show": "anonymized_show_id",
+        "endpoint": "aggregate",
+        "episode": "anonymized_episode_id"
+    },
+    "range": {
+        "start": "2025-08-23",
+        "end": "2025-08-23"
+    },
+    "data": {
+        "count": 0,
+        "ageFacetedCounts": {
+            "28-34": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "0-17": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "45-59": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "60-150": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "23-27": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "18-22": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "35-44": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "unknown": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            }
+        },
+        "genderedCounts": {
+            "counts": {
+                "FEMALE": 0,
+                "NON_BINARY": 0,
+                "MALE": 0,
+                "NOT_SPECIFIED": 0
+            }
+        }
+    }
+}

--- a/fixtures/spotifyEpisodeAggregateNoDateRangeWithCount.json
+++ b/fixtures/spotifyEpisodeAggregateNoDateRangeWithCount.json
@@ -1,0 +1,91 @@
+{
+    "provider": "spotify",
+    "version": 1,
+    "retrieved": "2025-08-25T21:51:31.292575",
+    "meta": {
+        "show": "anonymized_show_id",
+        "endpoint": "aggregate",
+        "episode": "anonymized_episode_id"
+    },
+    "range": {
+        "start": "2025-08-23",
+        "end": "2025-08-23"
+    },    
+    "data": {
+        "count": 5,
+        "ageFacetedCounts": {
+            "28-34": {
+                "counts": {
+                    "FEMALE": 2,
+                    "NON_BINARY": 0,
+                    "MALE": 3,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "0-17": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "45-59": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "60-150": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "23-27": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "18-22": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "35-44": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            },
+            "unknown": {
+                "counts": {
+                    "FEMALE": 0,
+                    "NON_BINARY": 0,
+                    "MALE": 0,
+                    "NOT_SPECIFIED": 0
+                }
+            }
+        },
+        "genderedCounts": {
+            "counts": {
+                "FEMALE": 2,
+                "NON_BINARY": 0,
+                "MALE": 3,
+                "NOT_SPECIFIED": 0
+            }
+        }
+    }
+}

--- a/src/api/connectors/SpotifyConnector.ts
+++ b/src/api/connectors/SpotifyConnector.ts
@@ -112,15 +112,27 @@ class SpotifyConnector implements ConnectorHandler {
                 )
             }
         } else if (payload.meta.endpoint === 'aggregate') {
+            const data = payload.data as any
+            if (!data.start || !data.end) {
+                // No date information available
+                if (data.count === 0) {
+                    // Skip processing for zero count without dates
+                    return
+                } else {
+                    throw new PayloadError(
+                        'Date information (start/end) is required when count > 0'
+                    )
+                }
+            }
+
             //validates the payload and throws an error if it is not valid
             validateJsonApiPayload(aggregateSchema, payload.data)
-            const data = payload.data as SpotifyEpisodeAggregatePayload
 
             if (payload.meta.episode !== undefined) {
                 return await this.repo.storeEpisodeAggregate(
                     accountId,
                     payload.meta.episode,
-                    data
+                    data as SpotifyEpisodeAggregatePayload
                 )
             } else {
                 return await this.repo.storePodcastAggregate(

--- a/tests/api_e2e/spotify.test.js
+++ b/tests/api_e2e/spotify.test.js
@@ -15,6 +15,9 @@ const spotifyImpressionsTotalPayload = require('../../fixtures/spotifyImpression
 const spotifyImpressionsDailyPayload = require('../../fixtures/spotifyImpressionsDailyPayload.json')
 const spotifyImpressionsFacetedPayload = require('../../fixtures/spotifyImpressionsFacetedPayload.json')
 const spotifyImpressionsFunnelPayload = require('../../fixtures/spotifyImpressionsFunnelPayload.json')
+const spotifyEpisodeAggregateNoDateRangePayload = require('../../fixtures/spotifyEpisodeAggregateNoDateRange.json')
+const spotifyEpisodeAggregateNoDateRangeWithCountPayload = require('../../fixtures/spotifyEpisodeAggregateNoDateRangeWithCount.json')
+
 
 const auth = require("./authheader")
 
@@ -166,6 +169,26 @@ describe('check Connector API with spotifyImpressionsFunnelPayload', () => {
             .post('/connector')
             .set(auth)
             .send(spotifyImpressionsFunnelPayload)
+        expect(response.statusCode).toBe(200)
+    })
+})
+
+describe('check Connector API with spotifyEpisodeAggregateNoDateRangePayload', () => {
+    it('should return status 200 when sending spotify episode aggregate with count=0 and no date range in data', async () => {
+        const response = await request(baseURL)
+            .post('/connector')
+            .set(auth)
+            .send(spotifyEpisodeAggregateNoDateRangePayload)
+        expect(response.statusCode).toBe(200)
+    })
+})
+
+describe('check Connector API with spotifyEpisodeAggregateNoDateRangeWithCountPayload', () => {
+    it('should return status 200 when sending spotify episode aggregate with count>0 and no date range in data', async () => {
+        const response = await request(baseURL)
+            .post('/connector')
+            .set(auth)
+            .send(spotifyEpisodeAggregateNoDateRangeWithCountPayload)
         expect(response.statusCode).toBe(200)
     })
 })


### PR DESCRIPTION
Ensure proper handling of Spotify episode aggregate payloads by validating the presence of start and end dates. Skip processing when the count is zero and no date information is available, while throwing an error if count is greater than zero without date information.

Fixes #195