### PR TITLE
Add provider ID columns to podcasts table and update related queriescharts endpoint

### DIFF
--- a/db_schema/migrations/16_podcasts_provider_ids.sql
+++ b/db_schema/migrations/16_podcasts_provider_ids.sql
@@ -1,0 +1,33 @@
+-- Migration 16: Add provider ID columns to podcasts table
+-- This migration adds four new columns to store provider-specific IDs
+-- and populates them from the openpodcast_auth.podcastSources table
+
+-- Add the new columns to the podcasts table
+ALTER TABLE podcasts 
+ADD COLUMN spotify_id VARCHAR(64) NULL,
+ADD COLUMN apple_id VARCHAR(64) NULL,
+ADD COLUMN podigee_id VARCHAR(64) NULL,
+ADD COLUMN anchor_id VARCHAR(64) NULL;
+
+-- Populate the new columns from the openpodcast_auth.podcastSources table
+UPDATE podcasts p
+LEFT JOIN openpodcast_auth.podcastSources ps_spotify 
+    ON p.account_id = ps_spotify.account_id 
+    AND ps_spotify.source_name = 'spotify'
+LEFT JOIN openpodcast_auth.podcastSources ps_apple 
+    ON p.account_id = ps_apple.account_id 
+    AND ps_apple.source_name = 'apple'
+LEFT JOIN openpodcast_auth.podcastSources ps_podigee 
+    ON p.account_id = ps_podigee.account_id 
+    AND ps_podigee.source_name = 'podigee'
+LEFT JOIN openpodcast_auth.podcastSources ps_anchor 
+    ON p.account_id = ps_anchor.account_id 
+    AND ps_anchor.source_name = 'anchor'
+SET 
+    p.spotify_id = ps_spotify.source_podcast_id,
+    p.apple_id = ps_apple.source_podcast_id,
+    p.podigee_id = ps_podigee.source_podcast_id,
+    p.anchor_id = ps_anchor.source_podcast_id;
+
+-- Record this migration as completed
+INSERT INTO migrations (migration_id, migration_name) VALUES (16, 'podcasts provider ids');

--- a/db_schema/queries/v1/chartRanking.sql
+++ b/db_schema/queries/v1/chartRanking.sql
@@ -1,0 +1,85 @@
+-- Chart rankings query using provider IDs from podcasts table
+-- Requires @account_id parameter to be set
+
+WITH podcast_ids AS (
+  SELECT 
+    account_id,
+    spotify_id,
+    apple_id,
+    podigee_id,
+    anchor_id
+  FROM podcasts 
+  WHERE account_id = @account_id
+  LIMIT 1
+)
+
+/* unified results with resolved categories/genres */
+SELECT 
+  'spotify'           AS platform,
+  'podcast'           AS item_type,
+  pc.showid           AS show_id,
+  NULL                AS episode_id,
+  pc.region           AS market,
+  pc.category         AS chart_name,
+  pc.position         AS position,
+  pc.date             AS chart_date
+FROM openpodcast_charts.podcast_charts pc
+INNER JOIN podcast_ids p ON pc.showid = p.spotify_id
+WHERE p.spotify_id IS NOT NULL
+  AND pc.date BETWEEN @start AND @end
+
+UNION ALL
+
+SELECT
+  'spotify'           AS platform,
+  'episode'           AS item_type,
+  ec.showid           AS show_id,
+  ec.episodeid        AS episode_id,
+  ec.region           AS market,
+  'top_episodes'      AS chart_name,
+  ec.position         AS position,
+  ec.date             AS chart_date
+FROM openpodcast_charts.episode_charts ec
+INNER JOIN podcast_ids p ON ec.showid = p.spotify_id
+WHERE p.spotify_id IS NOT NULL
+  AND ec.date BETWEEN @start AND @end
+
+UNION ALL
+
+SELECT
+  'apple'             AS platform,
+  'podcast'           AS item_type,
+  CAST(apc.id AS CHAR)        AS show_id,
+  NULL                AS episode_id,
+  apc.country         AS market,
+  ag.name             AS chart_name,
+  apc.position        AS position,
+  apc.date            AS chart_date
+FROM openpodcast_charts.apple_podcast_charts apc
+INNER JOIN podcast_ids p ON CAST(apc.id AS CHAR) = p.apple_id
+LEFT JOIN openpodcast_charts.apple_genres ag
+       ON apc.genre_id = ag.id
+      AND apc.country = ag.country
+WHERE p.apple_id IS NOT NULL
+  AND apc.date BETWEEN @start AND @end
+
+UNION ALL
+
+SELECT
+  'apple'             AS platform,
+  'episode'           AS item_type,
+  CAST(aec.podcast_id AS CHAR) AS show_id,
+  CAST(aec.episode_id AS CHAR) AS episode_id,
+  aec.country         AS market,
+  ag.name             AS chart_name,
+  aec.position        AS position,
+  aec.date            AS chart_date
+FROM openpodcast_charts.apple_episode_charts aec
+INNER JOIN podcast_ids p ON CAST(aec.podcast_id AS CHAR) = p.apple_id
+LEFT JOIN openpodcast_charts.apple_genres ag
+       ON aec.genre_id = ag.id
+      AND aec.country = ag.country
+WHERE p.apple_id IS NOT NULL
+  AND aec.date BETWEEN @start AND @end
+
+ORDER BY chart_date, platform, item_type, market, position;

--- a/db_schema/schema.sql
+++ b/db_schema/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS migrations (
 -- -----------------------------------------
 -- IMPORTANT: this is the schema version
 -- ID has to be incremented for each change
-INSERT INTO migrations (migration_id, migration_name) VALUES (15, 'spotify impressions');
+INSERT INTO migrations (migration_id, migration_name) VALUES (16, 'podcasts provider ids');
 -- -----------------------------------------
 
 CREATE TABLE IF NOT EXISTS events (
@@ -331,6 +331,11 @@ CREATE TABLE IF NOT EXISTS podcasts (
   pod_name VARCHAR(2048) NOT NULL,
   -- 1 if should be monitored and alerts should be sent
   monitored BOOLEAN NOT NULL DEFAULT 1,
+  -- Provider-specific IDs for chart lookups
+  spotify_id VARCHAR(64) NULL,
+  apple_id VARCHAR(64) NULL,
+  podigee_id VARCHAR(64) NULL,
+  anchor_id VARCHAR(64) NULL,
   PRIMARY KEY (account_id)
 );
 


### PR DESCRIPTION
Introduce new columns for provider-specific IDs in the podcasts table and update queries to utilize these IDs for chart rankings.