### PR TITLE
Fix schema.sql conflicts with migrations on fresh DB install

### DIFF
--- a/db_schema/schema.sql
+++ b/db_schema/schema.sql
@@ -703,7 +703,6 @@ CREATE TABLE IF NOT EXISTS anchorPodcastEpisodes (
   share_link_embed_path VARCHAR(512) NOT NULL,
   ad_count INTEGER NOT NULL,
   created DATETIME NOT NULL,
-  publishOn DATETIME,
   duration BIGINT NOT NULL,
   hour_offset INTEGER NOT NULL,
   is_deleted BOOLEAN NOT NULL,
@@ -761,9 +760,7 @@ CREATE TABLE IF NOT EXISTS hosterPodcastMetrics (
     'downloads',
     'platforms',
     'clients',
-    'sources',
-    'listeners',
-    'subscribers'
+    'sources'
   ) NOT NULL,
   subdimension SMALLINT UNSIGNED NOT NULL,
   value INTEGER NOT NULL,


### PR DESCRIPTION
## Issue

When running the API on a clean database instance, migrations were failing with the following errors:

### Error 1: Duplicate column 'publishOn'
```
Error: Duplicate column name 'publishOn'
    at PromisePool.query (/Users/mendler/Code/openpodcast/api/node_modules/mysql2/promise.js:341:22)
    at DBInitializer.runMigration (/Users/mendler/Code/openpodcast/api/src/db/DBInitializer.ts:113:24)
  code: 'ER_DUP_FIELDNAME',
  errno: 1060,
  sql: 'ALTER TABLE anchorPodcastEpisodes ADD COLUMN publishOn DATETIME DEFAULT NULL AFTER created',
  sqlMessage: "Duplicate column name 'publishOn'"
```

### Error 2: Table modification fails for hosterPodcastMetrics
```
Error: Table 'openpodcast.hosterPodcastMetrics' doesn't exist
  code: 'ER_NO_SUCH_TABLE',
  errno: 1146,
  sql: 'ALTER TABLE hosterPodcastMetrics MODIFY dimension ENUM(...)',
  sqlMessage: "Table 'openpodcast.hosterPodcastMetrics' doesn't exist"
```

## Root Cause

`schema.sql` contained changes that were supposed to be applied via migrations:
- The `publishOn` column (added by migration 6)
- The `listeners` and `subscribers` enum values for `hosterPodcastMetrics` (added by migration 17)

When migrations ran after `schema.sql` on a fresh DB, they tried to add/modify things that already existed.

## Solution

Remove migration changes from `schema.sql` so it reflects the base state **before** any migrations run. Migrations then apply changes incrementally:

- ✅ Removed `publishOn` column from `anchorPodcastEpisodes` table (will be added by migration 6)
- ✅ Removed `'listeners'` and `'subscribers'` from `hosterPodcastMetrics` dimension enum (will be added by migration 17)

This ensures `schema.sql` and migrations don't conflict on fresh installs while maintaining compatibility with existing databases that have already run these migrations.

## Testing

Tested with:
```bash
docker exec api-db-1 mysql -u openpodcast -popenpodcast -e "DROP DATABASE IF EXISTS openpodcast; CREATE DATABASE openpodcast;"
make dev
```

All migrations now run successfully on a fresh database.