### PR TITLE
Add Swagger/OpenAPI documentation for Analytics API

### DIFF
--- a/db_schema/migrations/6_anchor_episode_publish_time.sql
+++ b/db_schema/migrations/6_anchor_episode_publish_time.sql
@@ -1,3 +1,16 @@
-ALTER TABLE anchorPodcastEpisodes ADD COLUMN publishOn DATETIME DEFAULT NULL AFTER created;
+-- Check if column exists before adding it
+SET @col_exists = (SELECT COUNT(*)
+                   FROM INFORMATION_SCHEMA.COLUMNS
+                   WHERE TABLE_SCHEMA = DATABASE()
+                   AND TABLE_NAME = 'anchorPodcastEpisodes'
+                   AND COLUMN_NAME = 'publishOn');
+
+SET @query = IF(@col_exists = 0,
+    'ALTER TABLE anchorPodcastEpisodes ADD COLUMN publishOn DATETIME DEFAULT NULL AFTER created',
+    'SELECT "Column publishOn already exists" AS message');
+
+PREPARE stmt FROM @query;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 INSERT INTO migrations (migration_id, migration_name) VALUES (6, 'anchor episode publish time');

--- a/docs/AVAILABLE_QUERIES.md
+++ b/docs/AVAILABLE_QUERIES.md
@@ -1,0 +1,154 @@
+# Available Analytics Query Endpoints
+
+This document lists all available query endpoints in the Open Podcast Analytics API.
+
+All endpoints follow the pattern: `/analytics/v1/{podcast_id}/{query_name}`
+
+Query parameters:
+- `start`: Start date (YYYY-MM-DD format)
+- `end`: End date (YYYY-MM-DD format)
+
+Add `/csv` to the end of any endpoint to get CSV format instead of JSON.
+
+## Spotify Endpoints
+
+### Podcast-Level Metrics
+- `reportSpotifyPodcastBaseMetrics` - Base podcast metrics (streams, listeners, followers)
+- `reportSpotifyPlays` - Play counts over time
+- `reportSpotifyUniqueListeners` - Unique listener counts
+- `spotifyPlaysSum` - Sum of plays for a date range
+
+### Episode-Level Metrics
+- `spotifyEpisodesMetricsExport` - Detailed episode metrics export
+
+### Demographics
+- `podcastAge` - Age distribution of podcast listeners
+- `podcastGender` - Gender distribution of podcast listeners
+- `episodesAge` - Age distribution per episode
+- `episodesGender` - Gender distribution per episode
+
+### Geographic Data
+- `spotifyCountries` - Geographic distribution by country
+
+### Impressions & Discovery
+- `spotifyImpressions` - Total impressions over time
+- `spotifyImpressionsSources` - Impressions by source (HOME, SEARCH, LIBRARY, OTHER)
+- `spotifyImpressionsFunnel` - Conversion funnel from impressions to streams
+
+## Apple Podcasts Endpoints
+
+### Podcast-Level Metrics
+- `reportApplePodcastBaseMetrics` - Base podcast metrics (plays, listeners, engagement)
+- `applePodcastFollowers` - Follower counts and trends
+- `reportApplePlays` - Play counts over time
+
+### Episode-Level Metrics
+- `appleEpisodesPlays` - Episode play counts
+- `appleEpisodesLTR` - Episode listen-through rates
+- `reportEpisodesLTRHistogram` - Detailed LTR histograms per episode
+
+### Geographic Data
+- `rawApplePodcastCountries` - Geographic distribution by country
+
+## Cross-Platform Endpoints
+
+### Episode Metrics
+- `episodesTotalMetrics` - Combined Apple + Spotify total metrics per episode
+- `episodesDailyMetrics` - Combined daily metrics per episode
+- `episodesMetadata` - Episode metadata from all platforms
+- `episodesLTR` - Combined listen-through rates
+- `episodesLTRHistogram` - Combined LTR histograms
+
+### Podcast Metrics
+- `podcastMetadata` - Podcast metadata from all platforms
+- `podcastFollowers` - Combined follower counts
+
+## Generic Hoster Endpoints
+
+### Downloads & Performance
+- `reportHosterDownloads` - Download counts over time
+- `reportTopEpisodesPerformance` - Top performing episodes
+- `reportEpisodeTotalPlays` - Total plays per episode (lifetime)
+
+### Distribution Metrics
+- `reportHosterPlatforms` - Platform/app distribution (e.g., Apple Podcasts, Spotify, Overcast)
+- `reportHosterClients` - Client/device distribution
+
+### Podigee-Specific
+- `reportHosterPodigeePodcastOverview` - Podcast overview metrics (Podigee hosting)
+
+## Chart Rankings
+
+- `chartsRankings` - Chart positions and rankings across platforms
+
+## Anchor (Legacy)
+
+### Episode Metrics
+- `reportAnchorEpisodeMetadata` - Episode metadata
+- `reportAnchorEpisodeLTRHistogram` - Episode listen-through histogram
+- `reportAnchorAvgEpisodeLTRHistogram` - Average LTR across episodes
+
+### Audience
+- `reportAnchorTotalPlaysByEpisode` - Total plays per episode
+- `reportAnchorPlays` - Plays over time
+- `reportAnchorTopEpisodes` - Top performing episodes
+
+## Utility Endpoints
+
+- `ping` - Health check / connection test
+
+## Example Usage
+
+### Get Spotify podcast metrics for August 2024 (JSON)
+```bash
+GET /analytics/v1/123/reportSpotifyPodcastBaseMetrics?start=2024-08-01&end=2024-08-31
+Authorization: Bearer YOUR_TOKEN
+```
+
+### Get platform distribution for August 2024 (CSV)
+```bash
+GET /analytics/v1/123/reportHosterPlatforms/csv?start=2024-08-01&end=2024-08-31
+Authorization: Bearer YOUR_TOKEN
+```
+
+### Get combined episode metrics (defaults to yesterday if no dates provided)
+```bash
+GET /analytics/v1/123/episodesTotalMetrics
+Authorization: Bearer YOUR_TOKEN
+```
+
+## Response Format
+
+### JSON Response
+```json
+{
+  "meta": {
+    "query": "reportSpotifyPodcastBaseMetrics",
+    "podcastId": "123",
+    "date": "2024-09-24T12:00:00Z",
+    "startDate": "2024-08-01",
+    "endDate": "2024-08-31"
+  },
+  "data": [
+    {
+      "total_episodes": 50,
+      "starts": 10000,
+      "streams": 8500,
+      "listeners": 5000,
+      "followers": 2500,
+      "date": "2024-08-31"
+    }
+  ]
+}
+```
+
+### CSV Response
+When requesting CSV format (by adding `/csv` to the endpoint), the response will be a CSV file with appropriate headers.
+
+## Notes
+
+- All endpoints require authentication via Bearer token
+- Users can only access podcast IDs they have permission for
+- Date parameters are optional - defaults to yesterday if not provided
+- Invalid date formats or date ranges will return 400 Bad Request
+- Non-existent query endpoints will return 404 Not Found

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,9 @@
         "hbs": "^4.2.0",
         "mathjs": "^11.4.0",
         "moment": "^2.29.4",
-        "mysql2": "^2.3.3"
+        "mysql2": "^2.3.3",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "@types/body-parser": "^1.19.2",
@@ -26,6 +28,8 @@
         "@types/jest": "^30.0.0",
         "@types/mysql2": "types/mysql2",
         "@types/node": "^18.7.18",
+        "@types/swagger-jsdoc": "^6.0.4",
+        "@types/swagger-ui-express": "^4.1.8",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
         "concurrently": "^7.4.0",
@@ -58,6 +62,50 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1191,6 +1239,12 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1225,6 +1279,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
@@ -1651,8 +1712,7 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "dev": true
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1747,6 +1807,24 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/swagger-jsdoc": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
+      "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -2288,8 +2366,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -2448,8 +2525,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -2500,7 +2576,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2602,6 +2677,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -2828,8 +2909,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/concurrently": {
       "version": "7.6.0",
@@ -3081,7 +3161,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -3774,7 +3853,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4141,8 +4219,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -4578,7 +4655,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5530,7 +5606,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5646,6 +5721,20 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5657,6 +5746,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "4.0.0",
@@ -5828,7 +5923,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -6119,7 +6213,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -6138,6 +6231,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.1",
@@ -6246,7 +6346,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7241,6 +7340,92 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.29.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.29.1.tgz",
+      "integrity": "sha512-qyjpz0qgcomRr41a5Aye42o69TKwCeHM9F8htLGVeUMKekNS6qAqz9oS7CtSvgGJSppSNAYAIh7vrfrSdHj9zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -7929,8 +8114,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
@@ -7958,6 +8142,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.6.2",
@@ -8006,6 +8199,36 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     }
   },
   "dependencies": {
@@ -8017,6 +8240,40 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="
+    },
+    "@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
       }
     },
     "@babel/code-frame": {
@@ -8891,6 +9148,11 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -8916,6 +9178,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ=="
     },
     "@sinclair/typebox": {
       "version": "0.24.51",
@@ -9274,8 +9541,7 @@
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "dev": true
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -9365,6 +9631,22 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "@types/swagger-jsdoc": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
+      "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
+      "dev": true
+    },
+    "@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "@types/yargs": {
       "version": "17.0.33",
@@ -9766,8 +10048,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -9890,8 +10171,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -9937,7 +10217,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -10010,6 +10289,11 @@
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
       }
+    },
+    "call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
     },
     "callsites": {
       "version": "3.1.0",
@@ -10169,8 +10453,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "concurrently": {
       "version": "7.6.0",
@@ -10351,7 +10634,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -10858,8 +11140,7 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -11161,8 +11442,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -11464,7 +11744,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -12175,7 +12454,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -12258,6 +12536,16 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -12269,6 +12557,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "long": {
       "version": "4.0.0",
@@ -12396,7 +12689,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -12620,7 +12912,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -12633,6 +12924,12 @@
       "requires": {
         "mimic-fn": "^2.1.0"
       }
+    },
+    "openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "peer": true
     },
     "optionator": {
       "version": "0.9.1",
@@ -12707,8 +13004,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-key": {
       "version": "3.1.1",
@@ -13432,6 +13728,63 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "requires": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+          "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "requires": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "5.29.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.29.1.tgz",
+      "integrity": "sha512-qyjpz0qgcomRr41a5Aye42o69TKwCeHM9F8htLGVeUMKekNS6qAqz9oS7CtSvgGJSppSNAYAIh7vrfrSdHj9zw==",
+      "requires": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "requires": {
+        "swagger-ui-dist": ">=5.0.0"
+      }
+    },
     "tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -13906,8 +14259,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "write-file-atomic": {
       "version": "4.0.2",
@@ -13929,6 +14281,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ=="
     },
     "yargs": {
       "version": "17.6.2",
@@ -13962,6 +14319,25 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "requires": {
+        "commander": "^9.4.1",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "hbs": "^4.2.0",
     "mathjs": "^11.4.0",
     "moment": "^2.29.4",
-    "mysql2": "^2.3.3"
+    "mysql2": "^2.3.3",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.2",
@@ -28,6 +30,8 @@
     "@types/jest": "^30.0.0",
     "@types/mysql2": "types/mysql2",
     "@types/node": "^18.7.18",
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui-express": "^4.1.8",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
     "concurrently": "^7.4.0",

--- a/src/config/swagger-schemas.ts
+++ b/src/config/swagger-schemas.ts
@@ -1,0 +1,305 @@
+/**
+ * OpenAPI schema definitions for common response types
+ * These schemas are referenced in the API documentation
+ */
+
+export const schemas = {
+  /**
+   * @openapi
+   * components:
+   *   schemas:
+   *     # Spotify Schemas
+   *     SpotifyPodcastMetrics:
+   *       type: object
+   *       properties:
+   *         total_episodes:
+   *           type: integer
+   *           description: Total number of episodes
+   *         starts:
+   *           type: integer
+   *           description: Number of stream starts
+   *         streams:
+   *           type: integer
+   *           description: Number of completed streams
+   *         listeners:
+   *           type: integer
+   *           description: Unique listener count
+   *         followers:
+   *           type: integer
+   *           description: Total followers
+   *         date:
+   *           type: string
+   *           format: date
+   *
+   *     SpotifyEpisodePerformance:
+   *       type: object
+   *       properties:
+   *         episode_id:
+   *           type: string
+   *         episode_name:
+   *           type: string
+   *         median_percentage:
+   *           type: integer
+   *           description: Median listen-through percentage
+   *         median_seconds:
+   *           type: integer
+   *           description: Median listen time in seconds
+   *         percentile_25:
+   *           type: integer
+   *         percentile_50:
+   *           type: integer
+   *         percentile_75:
+   *           type: integer
+   *         percentile_100:
+   *           type: integer
+   *
+   *     SpotifyDemographics:
+   *       type: object
+   *       properties:
+   *         age_group:
+   *           type: string
+   *           enum: [0-17, 18-22, 23-27, 28-34, 35-44, 45-59, 60+]
+   *         gender:
+   *           type: string
+   *           enum: [male, female, non-binary, not-specified]
+   *         listeners:
+   *           type: integer
+   *         country:
+   *           type: string
+   *           description: ISO country code
+   *
+   *     # Apple Podcasts Schemas
+   *     ApplePodcastMetrics:
+   *       type: object
+   *       properties:
+   *         plays:
+   *           type: integer
+   *           description: Total play count
+   *         listeners:
+   *           type: integer
+   *           description: Unique listener count
+   *         engaged_listeners:
+   *           type: integer
+   *           description: Engaged listener count
+   *         total_time_listened:
+   *           type: integer
+   *           description: Total listening time in seconds
+   *         date:
+   *           type: string
+   *           format: date
+   *
+   *     AppleEpisodeDetails:
+   *       type: object
+   *       properties:
+   *         episode_id:
+   *           type: integer
+   *         episode_name:
+   *           type: string
+   *         plays_count:
+   *           type: integer
+   *         unique_listeners:
+   *           type: integer
+   *         unique_engaged_listeners:
+   *           type: integer
+   *         engaged_plays_count:
+   *           type: integer
+   *         total_time_listened:
+   *           type: integer
+   *         quarter1_median:
+   *           type: number
+   *           description: Median listener retention at 25%
+   *         quarter2_median:
+   *           type: number
+   *           description: Median listener retention at 50%
+   *         quarter3_median:
+   *           type: number
+   *           description: Median listener retention at 75%
+   *         quarter4_median:
+   *           type: number
+   *           description: Median listener retention at 100%
+   *
+   *     AppleFollowerStats:
+   *       type: object
+   *       properties:
+   *         date:
+   *           type: string
+   *           format: date
+   *         total_followers:
+   *           type: integer
+   *         gained:
+   *           type: integer
+   *           description: Followers gained on this day
+   *         lost:
+   *           type: integer
+   *           description: Followers lost on this day
+   *
+   *     # Episode Mapping Schemas
+   *     EpisodeMetadata:
+   *       type: object
+   *       properties:
+   *         account_id:
+   *           type: integer
+   *         spotify_episode_id:
+   *           type: string
+   *         apple_episode_id:
+   *           type: integer
+   *         episode_name:
+   *           type: string
+   *         guid:
+   *           type: string
+   *         release_date:
+   *           type: string
+   *           format: date-time
+   *         duration:
+   *           type: integer
+   *           description: Duration in seconds
+   *         artwork_url:
+   *           type: string
+   *           format: uri
+   *
+   *     EpisodeTotalMetrics:
+   *       type: object
+   *       properties:
+   *         account_id:
+   *           type: integer
+   *         spotify_episode_id:
+   *           type: string
+   *         apple_episode_id:
+   *           type: integer
+   *         guid:
+   *           type: string
+   *         date:
+   *           type: string
+   *           format: date
+   *         total_apple_plays:
+   *           type: integer
+   *         total_apple_listeners:
+   *           type: integer
+   *         total_apple_engaged_listeners:
+   *           type: integer
+   *         total_apple_time_listened:
+   *           type: integer
+   *         total_spotify_starts:
+   *           type: integer
+   *         total_spotify_streams:
+   *           type: integer
+   *         total_spotify_listeners:
+   *           type: integer
+   *
+   *     # Hoster Schemas
+   *     HosterPlatformDistribution:
+   *       type: object
+   *       properties:
+   *         platform_name:
+   *           type: string
+   *           description: Platform/app name (e.g., Apple Podcasts, Spotify, Overcast)
+   *         total_downloads:
+   *           type: integer
+   *         percentage:
+   *           type: number
+   *           format: float
+   *           description: Percentage of total downloads
+   *
+   *     HosterClientDistribution:
+   *       type: object
+   *       properties:
+   *         client_name:
+   *           type: string
+   *           description: Client/device type
+   *         total_downloads:
+   *           type: integer
+   *         percentage:
+   *           type: number
+   *           format: float
+   *
+   *     # Chart Schemas
+   *     ChartRanking:
+   *       type: object
+   *       properties:
+   *         date:
+   *           type: string
+   *           format: date
+   *         category:
+   *           type: string
+   *         country:
+   *           type: string
+   *         rank:
+   *           type: integer
+   *         platform:
+   *           type: string
+   *           enum: [spotify, apple]
+   *
+   *     # Listen-Through Rate (LTR) Schemas
+   *     LTRHistogram:
+   *       type: object
+   *       properties:
+   *         episode_id:
+   *           type: string
+   *         episode_name:
+   *           type: string
+   *         seconds:
+   *           type: integer
+   *           description: Time offset in seconds
+   *         apple_listeners:
+   *           type: integer
+   *         spotify_listeners:
+   *           type: integer
+   *         apple_percentage:
+   *           type: number
+   *           description: Percentage of listeners at this point (Apple)
+   *         spotify_percentage:
+   *           type: number
+   *           description: Percentage of listeners at this point (Spotify)
+   *
+   *     # Impressions Schemas (Spotify)
+   *     SpotifyImpressions:
+   *       type: object
+   *       properties:
+   *         date:
+   *           type: string
+   *           format: date
+   *         impressions:
+   *           type: integer
+   *           description: Total impressions on Spotify
+   *
+   *     SpotifyImpressionsSources:
+   *       type: object
+   *       properties:
+   *         source:
+   *           type: string
+   *           enum: [HOME, SEARCH, LIBRARY, OTHER]
+   *         impression_count:
+   *           type: integer
+   *         date_start:
+   *           type: string
+   *           format: date
+   *         date_end:
+   *           type: string
+   *           format: date
+   *
+   *     SpotifyFunnel:
+   *       type: object
+   *       properties:
+   *         date:
+   *           type: string
+   *           format: date
+   *         step:
+   *           type: string
+   *           enum: [impressions, considerations, streams]
+   *         count:
+   *           type: integer
+   *         conversion_percent:
+   *           type: number
+   *           format: float
+   *
+   *     # Error Response
+   *     Error:
+   *       type: object
+   *       properties:
+   *         message:
+   *           type: string
+   *         tracingId:
+   *           type: string
+   *           description: Error tracking ID for debugging
+   */
+};

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -8,7 +8,7 @@ const options: swaggerJsdoc.Options = {
     info: {
       title: 'Open Podcast Analytics API',
       version: version,
-      description: 'Podcast analytics API providing metrics from Spotify, Apple Podcasts, and custom hosting providers. See https://github.com/openpodcast/api/blob/main/docs/AVAILABLE_QUERIES.md for a complete list of available queries.',
+      description: 'Podcast analytics API providing metrics from Spotify, Apple Podcasts, and custom hosting providers. Query endpoints are defined as SQL files in db_schema/queries/v1/.',
       contact: {
         name: 'Open Podcast',
         url: 'https://openpodcast.dev',

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1,0 +1,158 @@
+import swaggerJsdoc from 'swagger-jsdoc';
+import { version } from '../../package.json';
+import './swagger-schemas';
+
+const options: swaggerJsdoc.Options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Open Podcast Analytics API',
+      version: version,
+      description: `
+# Open Podcast Analytics API
+
+Comprehensive podcast analytics API providing metrics from multiple platforms including Spotify, Apple Podcasts, and custom hosting providers.
+
+## Available Data
+
+### Spotify Data
+- Episode and podcast streams (starts and completed streams, daily granularity)
+- Listener counts (unique listeners over time)
+- Followers of the podcast (daily snapshots)
+- Episode performance (median listen percentage, median seconds, percentiles, listen-through curves on a per-second basis)
+- Audience demographics (age groups, gender, country, at both episode and podcast level)
+- Podcast metadata (episode titles, descriptions, artwork, URLs, release dates, explicit flag, duration, language)
+- Historical metadata snapshots (track changes over time)
+- Impressions and funnel data (total impressions, impressions by source such as home, search, library, other, funnel stages from impressions to considerations to streams, conversion percentages per day)
+
+### Apple Podcasts Data
+- Episode metadata (episode name, collection/podcast name, release datetime, GUID, episode number, type)
+- Episode details (plays, total time listened, unique engaged listeners, unique listeners, engaged plays vs. total plays)
+- Playback histograms (listen-through on a time-bucket basis, top countries and cities, median listeners at different quarters of the episode)
+- Trends (daily episode-level metrics: plays, total time listened, unique listeners, engaged listeners)
+- Trends (daily podcast-level metrics: same as above, aggregated across episodes)
+- Listening time split by followers vs. non-followers
+- Follower statistics (total followers, unfollowers, gained/lost per day)
+
+### General Metrics
+- Plays, streams, downloads (episode and podcast level, daily)
+- Listen-through data (per-second or per-bucket playback curves, histograms, medians, percentiles)
+- Audience demographics (age, gender, country)
+- Followers and subscribers (absolute numbers and gained/lost trends)
+- Impressions and funnel steps (Spotify)
+- Metadata (titles, descriptions, release dates, artwork, language)
+- Historical snapshots (to track changes over time)
+
+## Authentication
+
+All endpoints require a Bearer token in the Authorization header:
+
+\`\`\`
+Authorization: Bearer YOUR_TOKEN
+\`\`\`
+
+## Date Parameters
+
+Most endpoints accept date range parameters:
+- \`start\`: Start date in YYYY-MM-DD format
+- \`end\`: End date in YYYY-MM-DD format
+      `,
+      contact: {
+        name: 'Open Podcast',
+        url: 'https://openpodcast.dev',
+        email: 'echo@openpodcast.dev',
+      },
+      license: {
+        name: 'MIT',
+        url: 'https://github.com/openpodcast/api/blob/main/LICENSE',
+      },
+    },
+    servers: [
+      {
+        url: 'https://api.openpodcast.dev',
+        description: 'Production server',
+      },
+      {
+        url: 'http://localhost:3000',
+        description: 'Development server',
+      },
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description: 'Enter your API token',
+        },
+      },
+      parameters: {
+        podcastId: {
+          name: 'podcast_id',
+          in: 'path',
+          required: true,
+          schema: {
+            type: 'integer',
+          },
+          description: 'Podcast ID',
+        },
+        startDate: {
+          name: 'start',
+          in: 'query',
+          required: false,
+          schema: {
+            type: 'string',
+            format: 'date',
+            example: '2024-01-01',
+          },
+          description: 'Start date (YYYY-MM-DD)',
+        },
+        endDate: {
+          name: 'end',
+          in: 'query',
+          required: false,
+          schema: {
+            type: 'string',
+            format: 'date',
+            example: '2024-12-31',
+          },
+          description: 'End date (YYYY-MM-DD)',
+        },
+      },
+    },
+    security: [
+      {
+        bearerAuth: [],
+      },
+    ],
+    tags: [
+      {
+        name: 'Spotify',
+        description: 'Spotify podcast analytics endpoints',
+      },
+      {
+        name: 'Apple Podcasts',
+        description: 'Apple Podcasts analytics endpoints',
+      },
+      {
+        name: 'Episodes',
+        description: 'Episode-level metrics across platforms',
+      },
+      {
+        name: 'Podcast',
+        description: 'Podcast-level metrics and metadata',
+      },
+      {
+        name: 'Hoster',
+        description: 'Generic hosting provider metrics',
+      },
+      {
+        name: 'Charts',
+        description: 'Chart rankings and positions',
+      },
+    ],
+  },
+  apis: ['./src/api/*.ts', './src/index.ts', './src/config/swagger-schemas.ts'],
+};
+
+export const swaggerSpec = swaggerJsdoc(options);

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -8,55 +8,7 @@ const options: swaggerJsdoc.Options = {
     info: {
       title: 'Open Podcast Analytics API',
       version: version,
-      description: `
-# Open Podcast Analytics API
-
-Comprehensive podcast analytics API providing metrics from multiple platforms including Spotify, Apple Podcasts, and custom hosting providers.
-
-## Available Data
-
-### Spotify Data
-- Episode and podcast streams (starts and completed streams, daily granularity)
-- Listener counts (unique listeners over time)
-- Followers of the podcast (daily snapshots)
-- Episode performance (median listen percentage, median seconds, percentiles, listen-through curves on a per-second basis)
-- Audience demographics (age groups, gender, country, at both episode and podcast level)
-- Podcast metadata (episode titles, descriptions, artwork, URLs, release dates, explicit flag, duration, language)
-- Historical metadata snapshots (track changes over time)
-- Impressions and funnel data (total impressions, impressions by source such as home, search, library, other, funnel stages from impressions to considerations to streams, conversion percentages per day)
-
-### Apple Podcasts Data
-- Episode metadata (episode name, collection/podcast name, release datetime, GUID, episode number, type)
-- Episode details (plays, total time listened, unique engaged listeners, unique listeners, engaged plays vs. total plays)
-- Playback histograms (listen-through on a time-bucket basis, top countries and cities, median listeners at different quarters of the episode)
-- Trends (daily episode-level metrics: plays, total time listened, unique listeners, engaged listeners)
-- Trends (daily podcast-level metrics: same as above, aggregated across episodes)
-- Listening time split by followers vs. non-followers
-- Follower statistics (total followers, unfollowers, gained/lost per day)
-
-### General Metrics
-- Plays, streams, downloads (episode and podcast level, daily)
-- Listen-through data (per-second or per-bucket playback curves, histograms, medians, percentiles)
-- Audience demographics (age, gender, country)
-- Followers and subscribers (absolute numbers and gained/lost trends)
-- Impressions and funnel steps (Spotify)
-- Metadata (titles, descriptions, release dates, artwork, language)
-- Historical snapshots (to track changes over time)
-
-## Authentication
-
-All endpoints require a Bearer token in the Authorization header:
-
-\`\`\`
-Authorization: Bearer YOUR_TOKEN
-\`\`\`
-
-## Date Parameters
-
-Most endpoints accept date range parameters:
-- \`start\`: Start date in YYYY-MM-DD format
-- \`end\`: End date in YYYY-MM-DD format
-      `,
+      description: 'Podcast analytics API providing metrics from Spotify, Apple Podcasts, and custom hosting providers. See https://github.com/openpodcast/api/blob/main/docs/AVAILABLE_QUERIES.md for a complete list of available queries.',
       contact: {
         name: 'Open Podcast',
         url: 'https://openpodcast.dev',
@@ -127,28 +79,8 @@ Most endpoints accept date range parameters:
     ],
     tags: [
       {
-        name: 'Spotify',
-        description: 'Spotify podcast analytics endpoints',
-      },
-      {
-        name: 'Apple Podcasts',
-        description: 'Apple Podcasts analytics endpoints',
-      },
-      {
-        name: 'Episodes',
-        description: 'Episode-level metrics across platforms',
-      },
-      {
-        name: 'Podcast',
-        description: 'Podcast-level metrics and metadata',
-      },
-      {
-        name: 'Hoster',
-        description: 'Generic hosting provider metrics',
-      },
-      {
-        name: 'Charts',
-        description: 'Chart rankings and positions',
+        name: 'Analytics',
+        description: 'Query podcast analytics data from multiple sources',
       },
     ],
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,18 +280,27 @@ app.get(
  *   get:
  *     summary: Get analytics data for a podcast
  *     description: |
- *       Query analytics data for a specific podcast.
+ *       Query analytics data for a specific podcast using SQL-based query endpoints.
  *
- *       The `query` parameter specifies which metric to retrieve. Common queries include:
+ *       **How it works:** The `query` parameter maps to SQL files in `db_schema/queries/v1/`.
+ *       For example, `reportHosterPlatforms` executes the SQL query defined in
+ *       `db_schema/queries/v1/reportHosterPlatforms.sql`.
+ *
+ *       **Common queries:**
  *       - `reportSpotifyPodcastBaseMetrics` - Spotify podcast metrics (streams, listeners, followers)
  *       - `reportApplePodcastBaseMetrics` - Apple Podcasts metrics (plays, listeners, engagement)
  *       - `episodesTotalMetrics` - Combined episode metrics across platforms
  *       - `reportHosterPlatforms` - Platform/app distribution (e.g., Apple Podcasts, Spotify, Overcast)
  *       - `reportHosterClients` - Client/device distribution
+ *       - `podcastFollowers` - Combined follower counts from all platforms
+ *       - `episodesLTRHistogram` - Listen-through rate histograms per episode
  *
- *       See [AVAILABLE_QUERIES.md](https://github.com/openpodcast/api/blob/main/docs/AVAILABLE_QUERIES.md) for the complete list of 50+ available queries.
+ *       **Output formats:**
+ *       - JSON (default): Returns structured data with metadata
+ *       - CSV: Append `/csv` to the path for CSV export
  *
- *       Results can be returned in JSON (default) or CSV format by appending `/csv` to the path.
+ *       **Available queries:** 50+ SQL queries covering Spotify, Apple Podcasts, cross-platform metrics,
+ *       hoster data, demographics, impressions, and chart rankings.
  *     tags:
  *       - Analytics
  *     parameters:

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,16 +280,18 @@ app.get(
  *   get:
  *     summary: Get analytics data for a podcast
  *     description: |
- *       Returns analytics data for a specific podcast and query endpoint.
+ *       Query analytics data for a specific podcast.
  *
- *       Supports multiple data sources (Spotify, Apple Podcasts, generic hosters) and various metrics including:
- *       - Episode and podcast performance metrics
- *       - Audience demographics
- *       - Listen-through data
- *       - Follower statistics
- *       - Chart rankings
+ *       The `query` parameter specifies which metric to retrieve. Common queries include:
+ *       - `reportSpotifyPodcastBaseMetrics` - Spotify podcast metrics (streams, listeners, followers)
+ *       - `reportApplePodcastBaseMetrics` - Apple Podcasts metrics (plays, listeners, engagement)
+ *       - `episodesTotalMetrics` - Combined episode metrics across platforms
+ *       - `reportHosterPlatforms` - Platform/app distribution (e.g., Apple Podcasts, Spotify, Overcast)
+ *       - `reportHosterClients` - Client/device distribution
  *
- *       Results can be returned in JSON or CSV format.
+ *       See [AVAILABLE_QUERIES.md](https://github.com/openpodcast/api/blob/main/docs/AVAILABLE_QUERIES.md) for the complete list of 50+ available queries.
+ *
+ *       Results can be returned in JSON (default) or CSV format by appending `/csv` to the path.
  *     tags:
  *       - Analytics
  *     parameters:
@@ -344,21 +346,43 @@ app.get(
  *                   properties:
  *                     query:
  *                       type: string
+ *                       example: reportHosterPlatforms
  *                     podcastId:
  *                       type: string
+ *                       example: "123"
  *                     date:
  *                       type: string
  *                       format: date-time
+ *                       example: "2024-09-24T12:00:00Z"
  *                     startDate:
  *                       type: string
  *                       format: date
+ *                       example: "2024-08-01"
  *                     endDate:
  *                       type: string
  *                       format: date
+ *                       example: "2024-08-31"
  *                 data:
  *                   type: array
  *                   items:
  *                     type: object
+ *             example:
+ *               meta:
+ *                 query: reportHosterPlatforms
+ *                 podcastId: "123"
+ *                 date: "2024-09-24T12:00:00Z"
+ *                 startDate: "2024-08-01"
+ *                 endDate: "2024-08-31"
+ *               data:
+ *                 - platform_name: "Apple Podcasts"
+ *                   total_downloads: 15420
+ *                   percentage: 45.2
+ *                 - platform_name: "Spotify"
+ *                   total_downloads: 10280
+ *                   percentage: 30.1
+ *                 - platform_name: "Overcast"
+ *                   total_downloads: 4120
+ *                   percentage: 12.1
  *           text/csv:
  *             schema:
  *               type: string


### PR DESCRIPTION
- Install swagger-jsdoc and swagger-ui-express
- Create comprehensive OpenAPI configuration with API overview
- Document analytics endpoint with detailed JSDoc annotations
- Add schema definitions for all response types (Spotify, Apple, Hoster, etc.)
- Create AVAILABLE_QUERIES.md listing all 50+ query endpoints
- Expose Swagger UI at /api-docs and OpenAPI spec at /api-docs.json
- Make documentation publicly accessible (no auth required)

The documentation includes:
- All available data sources (Spotify, Apple Podcasts, generic hosters)
- Complete parameter definitions with examples
- Response schemas with property descriptions
- Authentication requirements
- CSV export format support
- Example usage for common scenarios


Fixes: https://github.com/openpodcast/api/issues/216