### PR TITLE
Be more permissive around handling gender data

### DIFF
--- a/fixtures/anchorPlaysByGenderEmpty.json
+++ b/fixtures/anchorPlaysByGenderEmpty.json
@@ -1,0 +1,35 @@
+{
+  "provider": "anchor",
+  "version": 1,
+  "retrieved": "2023-05-05T16:20:56.696026",
+  "meta": {
+    "show": "123abcde",
+    "endpoint": "playsByGender"
+  },
+  "range": {
+    "start": "2023-05-01",
+    "end": "2023-05-04"
+  },
+  "data": {
+    "stationId": 98765432,
+    "kind": "playsByGender",
+    "parameters": {
+      "timeRange": []
+    },
+    "data": {
+      "rows": [],
+      "columnHeaders": [
+        {
+          "name": "Gender",
+          "type": "string"
+        },
+        {
+          "name": "Percent of Plays",
+          "type": "number"
+        }
+      ],
+      "translationMapping": {},
+      "colors": {}
+    }
+  }
+}

--- a/src/schema/anchor/playsByGender.json
+++ b/src/schema/anchor/playsByGender.json
@@ -100,11 +100,18 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "Female",
-                "Male",
-                "Non-binary",
-                "Not specified"
+              "anyOf": [
+                {
+                  "maxProperties": 0
+                },
+                {
+                  "required": [
+                    "Female",
+                    "Male",
+                    "Non-binary",
+                    "Not specified"
+                  ]
+                }
               ]
             },
             "columnHeaders": {
@@ -141,11 +148,18 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "Male",
-                "Female",
-                "Not specified",
-                "Non-binary"
+              "anyOf": [
+                {
+                  "maxProperties": 0
+                },
+                {
+                  "required": [
+                    "Male",
+                    "Female",
+                    "Not specified",
+                    "Non-binary"
+                  ]
+                }
               ]
             }
           },

--- a/tests/api_e2e/anchor.test.js
+++ b/tests/api_e2e/anchor.test.js
@@ -11,6 +11,7 @@ const anchorPlaysByAgeRangePayload = require('../../fixtures/anchorPlaysByAgeRan
 const anchorPlaysByAppPayload = require('../../fixtures/anchorPlaysByApp.json')
 const anchorPlaysByDevicePayload = require('../../fixtures/anchorPlaysByDevice.json')
 const anchorPlaysByGenderPayload = require('../../fixtures/anchorPlaysByGender.json')
+const anchorPlaysByGenderEmptyPayload = require('../../fixtures/anchorPlaysByGenderEmpty.json')
 const anchorPlaysByGeoPayload = require('../../fixtures/anchorPlaysByGeo.json')
 const anchorPodcastEpisodePayload = require('../../fixtures/anchorPodcastEpisode.json')
 const anchorTotalPlaysPayload = require('../../fixtures/anchorTotalPlays.json')
@@ -166,6 +167,16 @@ describe('check Connector API with anchorPlaysByGenderPayload', () => {
             .post('/connector')
             .set(auth)
             .send(anchorPlaysByGenderPayload)
+        expect(response.statusCode).toBe(200)
+    })
+})
+
+describe('check Connector API with anchorPlaysByGenderEmptyPayload', () => {
+    it('should return status 200 when sending Anchor playsByGender payload with empty translationMapping and colors', async () => {
+        const response = await request(baseURL)
+            .post('/connector')
+            .set(auth)
+            .send(anchorPlaysByGenderEmptyPayload)
         expect(response.statusCode).toBe(200)
     })
 })


### PR DESCRIPTION
Previously, we required all gender data to be in the payload. That is not always the case. So we changed the behavior to accept either empty payloads or payloads with all four values.

Supersedes #224 